### PR TITLE
fix: support implicitly unwrapped optionals

### DIFF
--- a/Sources/MockableMacro/Generator/Helpers/VariableDeclaration.swift
+++ b/Sources/MockableMacro/Generator/Helpers/VariableDeclaration.swift
@@ -147,7 +147,7 @@ extension VariableDeclaration {
 
     private var wrappedType: TypeSyntax {
         get throws {
-            let description = try type.trimmedDescription
+            let description = try trimmedType.trimmedDescription
             let typeName = "\(Constants.parameterWrapperName)<\(description)>"
             return .init(stringLiteral: typeName)
         }

--- a/Sources/MockableMacro/Generator/Members/BuilderStructs.swift
+++ b/Sources/MockableMacro/Generator/Members/BuilderStructs.swift
@@ -135,7 +135,7 @@ extension BuilderStructs {
 
     private func variableMembers(kind: Builder) throws -> [String] {
         try variables.map {
-            let propType = try $0.type.trimmedDescription
+            let propType = try $0.trimmedType.trimmedDescription
             let propName = try $0.name
             let returnType = try builderReturnType(for: $0, kind: kind)
             let signature = if $0.isComputed || kind == .return {

--- a/Sources/MockableTest/Utils.swift
+++ b/Sources/MockableTest/Utils.swift
@@ -11,7 +11,7 @@ import XCTest
 /// Creates a proxy for building return values for members of the given service.
 ///
 /// Example usage of `given(_ service:)`:
-///```swift
+/// ```swift
 /// // Throw an error for the first call and then return 'product' for every other call
 /// given(productService)
 ///     .fetch(for: .any).willThrow(error)

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -15,14 +15,14 @@ final class PropertyRequirementTests: MockableMacroTestCase {
           @Mockable
           protocol Test {
               var computedInt: Int { get }
-              var computedString: String { get }
+              var computedString: String! { get }
           }
           """
         } expansion: {
             """
             protocol Test {
                 var computedInt: Int { get }
-                var computedString: String { get }
+                var computedString: String! { get }
             }
 
             #if MOCKING
@@ -54,7 +54,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                var computedString: String {
+                var computedString: String! {
                     get {
                         let member: Member = .m2_computedString
                         return try! mocker.mock(member) { producer in

--- a/Tests/MockableTests/Protocols/TestProtocol.swift
+++ b/Tests/MockableTests/Protocols/TestProtocol.swift
@@ -53,7 +53,7 @@ protocol TestProtocol {
     var computedInt: Int { get }
     var computedString: String { get }
     var mutableInt: Int { get set }
-    var mutableString: String { get set }
+    var mutableUnwrappedString: String! { get set }
     var throwingProperty: Int { get throws }
     var asyncProperty: String { get async }
     var asyncThrowingProperty: String { get async throws }


### PR DESCRIPTION
Fix implicitly unwrapped optional requirement conformances in:
- Enum case declaration parameters
- Builder return types