### PR TITLE
Added support for same functions with different return types

### DIFF
--- a/Sources/Mockable/Builder/FunctionBuilders/FunctionActionBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/FunctionActionBuilder.swift
@@ -9,7 +9,7 @@
 ///
 /// This builder is used within the context of a higher-level builder (e.g., an `ActionBuilder`)
 /// to specify a desired action to perform when a particular function of a mock service is called.
-public struct FunctionActionBuilder<T: Mockable, ParentBuilder: EffectBuilder<T>> {
+public struct FunctionActionBuilder<T: Mockable, ParentBuilder: EffectBuilder<T>, ReturnType> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/FunctionBuilders/FunctionVerifyBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/FunctionVerifyBuilder.swift
@@ -9,7 +9,7 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., a `VerifyBuilder`)
 /// to verify the expected number of invocations for a particular function of a mock service.
-public struct FunctionVerifyBuilder<T: Mockable, ParentBuilder: AssertionBuilder<T>> {
+public struct FunctionVerifyBuilder<T: Mockable, ParentBuilder: AssertionBuilder<T>, ReturnType> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionActionBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionActionBuilder.swift
@@ -9,5 +9,5 @@
 ///
 /// This builder is used within the context of a higher-level builder (e.g., an `ActionBuilder`)
 /// to specify a desired action to perform when a particular throwing function of a mock service is called.
-public typealias ThrowingFunctionActionBuilder<T: Mockable, ParentBuilder: EffectBuilder<T>>
-    = FunctionActionBuilder<T, ParentBuilder>
+public typealias ThrowingFunctionActionBuilder<T: Mockable, ParentBuilder: EffectBuilder<T>, ReturnType>
+    = FunctionActionBuilder<T, ParentBuilder, ReturnType>

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionVerifyBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionVerifyBuilder.swift
@@ -9,5 +9,5 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., a `VerifyBuilder`)
 /// to verify the expected number of invocations for a throwing function of a mock service.
-public typealias ThrowingFunctionVerifyBuilder<T: Mockable, ParentBuilder: AssertionBuilder<T>>
-    = FunctionVerifyBuilder<T, ParentBuilder>
+public typealias ThrowingFunctionVerifyBuilder<T: Mockable, ParentBuilder: AssertionBuilder<T>, ReturnType>
+    = FunctionVerifyBuilder<T, ParentBuilder, ReturnType>

--- a/Sources/MockableMacro/Generator/Helpers/FunctionDeclaration.swift
+++ b/Sources/MockableMacro/Generator/Helpers/FunctionDeclaration.swift
@@ -113,7 +113,9 @@ extension FunctionDeclaration {
     var filteredGenericParameterClause: GenericParameterClauseSyntax? {
         guard let generics = syntax.genericParameterClause else { return nil }
         var parameters = generics.parameters.filter { generic in
-            hasParameter(containing: generic.name.trimmedDescription)
+            let hasParameter = hasParameter(containing: generic.name.trimmedDescription)
+            let hasReturn = hasReturn(containing: generic.name.trimmedDescription)
+            return hasParameter || hasReturn
         }
         if let lastIndex = parameters.indices.last {
             var last = parameters[lastIndex]
@@ -181,6 +183,21 @@ extension FunctionDeclaration {
             return found
         }
         tokenFinder.walk(syntax.signature.parameterClause)
+        return found
+    }
+    
+    private func hasReturn(containing identifier: String) -> Bool {
+        guard let returnClause = syntax.signature.returnClause else {
+            return false
+        }
+        var found = false
+        let identifier: TokenKind = .identifier(identifier)
+        let tokenFinder = TokenFinder {
+            guard !found else { return true }
+            found = found || $0.tokenKind == identifier
+            return found
+        }
+        tokenFinder.walk(returnClause)
         return found
     }
 

--- a/Sources/MockableMacro/Generator/Members/BuilderStructs.swift
+++ b/Sources/MockableMacro/Generator/Members/BuilderStructs.swift
@@ -183,7 +183,15 @@ extension BuilderStructs {
         let throwsPrefix = try variable.isThrowing ? "Throwing" : ""
         let propType = try variable.trimmedType.trimmedDescription
         let produceType = kind == .return ? ", \(try variable.closureType)" : ""
-        let returnType = kind == .return ? ", \(propType)" : ""
+        let returnType: String = {
+            if kind == .return {
+                ", \(propType)"
+            } else if variable.isComputed {
+                ", \(propType)"
+            } else {
+                ""
+            }
+        }()
         return if variable.isComputed {
             "\(throwsPrefix)Function\(kind.name)<\(mockName), \(kind.name)\(returnType)\(produceType)>"
         } else {
@@ -195,7 +203,7 @@ extension BuilderStructs {
         let throwsPrefix = function.isThrowing ? "Throwing" : ""
         let functionReturnType = function.returnType?.trimmedDescription ?? "Void"
         let produceType = kind == .return ? ", \(function.closureType)" : ""
-        let returnType = kind == .return ? ", \(functionReturnType)" : ""
+        let returnType = ", \(functionReturnType)"
         return "\(throwsPrefix)Function\(kind.name)<\(mockName), \(kind.name)\(returnType)\(produceType)>"
     }
 

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -76,7 +76,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder, Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
@@ -87,7 +87,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Item> {
                         .init(mocker, kind: .m1_foo(item: item), assertion: assertion)
                     }
                 }
@@ -164,7 +164,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder, Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
@@ -175,7 +175,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Item> {
                         .init(mocker, kind: .m1_foo(item: item), assertion: assertion)
                     }
                 }
@@ -252,7 +252,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder, Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
@@ -263,7 +263,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Item> {
                         .init(mocker, kind: .m1_foo(item: item), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -74,7 +74,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func modifyValue(_ value: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m1_modifyValue(value))
                     }
                 }
@@ -85,7 +85,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func modifyValue(_ value: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m1_modifyValue(value), assertion: assertion)
                     }
                 }
@@ -160,7 +160,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func printValues(_ values: Parameter<[Int]>) -> FunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m1_printValues(values))
                     }
                 }
@@ -171,7 +171,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func printValues(_ values: Parameter<[Int]>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m1_printValues(values), assertion: assertion)
                     }
                 }
@@ -246,7 +246,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> FunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
@@ -257,7 +257,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m1_execute(operation: operation), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -91,10 +91,10 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func returnsAndThrows() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func returnsAndThrows() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    func canThrowError() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func canThrowError() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
@@ -105,10 +105,10 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func returnsAndThrows() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func returnsAndThrows() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m1_returnsAndThrows, assertion: assertion)
                     }
-                    func canThrowError() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func canThrowError() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m2_canThrowError, assertion: assertion)
                     }
                 }
@@ -183,7 +183,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> FunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
@@ -194,7 +194,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m1_execute(operation: operation), assertion: assertion)
                     }
                 }
@@ -300,13 +300,13 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func asyncFunction() -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func asyncFunction() -> FunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    func asyncThrowingFunction() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func asyncThrowingFunction() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }
@@ -317,13 +317,13 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func asyncFunction() -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func asyncFunction() -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m1_asyncFunction, assertion: assertion)
                     }
-                    func asyncThrowingFunction() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func asyncThrowingFunction() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m2_asyncThrowingFunction, assertion: assertion)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -74,7 +74,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> FunctionActionBuilder<MockTest, ActionBuilder, Void> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()))
                     }
                 }
@@ -85,7 +85,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Void> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()), assertion: assertion)
                     }
                 }
@@ -160,7 +160,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func genericFunc<T>(item: Parameter<T>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func genericFunc<T, V>(item: Parameter<T>) -> FunctionActionBuilder<MockTest, ActionBuilder, V> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()))
                     }
                 }
@@ -171,7 +171,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func genericFunc<T>(item: Parameter<T>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func genericFunc<T, V>(item: Parameter<T>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, V> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()), assertion: assertion)
                     }
                 }
@@ -256,7 +256,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         self.mocker = mocker
                     }
                     func method1<T: Hashable, E, C, I>(
-                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> FunctionActionBuilder<MockTest, ActionBuilder> where E: Equatable, E: Hashable, C: Codable {
+                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> FunctionActionBuilder<MockTest, ActionBuilder, Void> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()))
                     }
@@ -269,7 +269,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         self.assertion = assertion
                     }
                     func method1<T: Hashable, E, C, I>(
-                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> where E: Equatable, E: Hashable, C: Codable {
+                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Void> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()), assertion: assertion)
                     }

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -90,10 +90,10 @@ final class NameCollisionTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func fetchData(for name: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(for name: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m1_fetchData(for: name))
                     }
-                    func fetchData(for name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(for name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m2_fetchData(for: name))
                     }
                 }
@@ -104,10 +104,10 @@ final class NameCollisionTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func fetchData(for name: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(for name: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m1_fetchData(for: name), assertion: assertion)
                     }
-                    func fetchData(for name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(for name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m2_fetchData(for: name), assertion: assertion)
                     }
                 }
@@ -198,10 +198,10 @@ final class NameCollisionTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func fetchData(forA name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(forA name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m1_fetchData(forA: name))
                     }
-                    func fetchData(forB name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(forB name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m2_fetchData(forB: name))
                     }
                 }
@@ -212,11 +212,119 @@ final class NameCollisionTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func fetchData(forA name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(forA name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m1_fetchData(forA: name), assertion: assertion)
                     }
-                    func fetchData(forB name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(forB name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m2_fetchData(forB: name), assertion: assertion)
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+    
+    func test_same_name_same_type_params_different_return_type() {
+        assertMacro {
+          """
+          @Mockable
+          protocol Test {
+              func fetchData(for name: Int) -> String
+              func fetchData(for name: String) -> Int
+          }
+          """
+        } expansion: {
+            """
+            protocol Test {
+                func fetchData(for name: Int) -> String
+                func fetchData(for name: String) -> Int
+            }
+
+            #if MOCKING
+            final class MockTest: Test, Mockable {
+                private var mocker = Mocker<MockTest>()
+                @available(*, deprecated, message: "Use given(_ service:) of MockableTest instead.")
+                func given() -> ReturnBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use when(_ service:) of MockableTest instead.")
+                func when() -> ActionBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead.")
+                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                    .init(mocker: mocker, assertion: assertion)
+                }
+                func reset(_ scopes: Set<Scope> = .all) {
+                    mocker.reset(scopes: scopes)
+                }
+                init() {
+                }
+                func fetchData(for name: Int) -> String {
+                    let member: Member = .m1_fetchData(for: .value(name))
+                    return try! mocker.mock(member) { producer in
+                        let producer = try cast(producer) as (Int) -> String
+                        return producer(name)
+                    }
+                }
+                func fetchData(for name: String) -> Int {
+                    let member: Member = .m2_fetchData(for: .value(name))
+                    return try! mocker.mock(member) { producer in
+                        let producer = try cast(producer) as (String) -> Int
+                        return producer(name)
+                    }
+                }
+                enum Member: Matchable, CaseIdentifiable {
+                    case m1_fetchData(for: Parameter<Int>)
+                    case m2_fetchData(for: Parameter<String>)
+                    func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_fetchData(for: let leftFor), .m1_fetchData(for: let rightFor)):
+                            return leftFor.match(rightFor)
+                        case (.m2_fetchData(for: let leftFor), .m2_fetchData(for: let rightFor)):
+                            return leftFor.match(rightFor)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                struct ReturnBuilder: EffectBuilder {
+                    private let mocker: Mocker<MockTest>
+                    init(mocker: Mocker<MockTest>) {
+                        self.mocker = mocker
+                    }
+                    func fetchData(for name: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Int) -> String> {
+                        .init(mocker, kind: .m1_fetchData(for: name))
+                    }
+                    func fetchData(for name: Parameter<String>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (String) -> Int> {
+                        .init(mocker, kind: .m2_fetchData(for: name))
+                    }
+                }
+                struct ActionBuilder: EffectBuilder {
+                    private let mocker: Mocker<MockTest>
+                    init(mocker: Mocker<MockTest>) {
+                        self.mocker = mocker
+                    }
+                    func fetchData(for name: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder, String> {
+                        .init(mocker, kind: .m1_fetchData(for: name))
+                    }
+                    func fetchData(for name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder, Int> {
+                        .init(mocker, kind: .m2_fetchData(for: name))
+                    }
+                }
+                struct VerifyBuilder: AssertionBuilder {
+                    private let mocker: Mocker<MockTest>
+                    private let assertion: MockableAssertion
+                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                        self.mocker = mocker
+                        self.assertion = assertion
+                    }
+                    func fetchData(for name: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
+                        .init(mocker, kind: .m1_fetchData(for: name), assertion: assertion)
+                    }
+                    func fetchData(for name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder, Int> {
+                        .init(mocker, kind: .m2_fetchData(for: name), assertion: assertion)
                     }
                 }
             }

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -94,10 +94,10 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    var computedInt: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var computedInt: FunctionActionBuilder<MockTest, ActionBuilder, Int> {
                         .init(mocker, kind: .m1_computedInt)
                     }
-                    var computedString: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var computedString: FunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m2_computedString)
                     }
                 }
@@ -108,10 +108,10 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var computedInt: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var computedInt: FunctionVerifyBuilder<MockTest, VerifyBuilder, Int> {
                         .init(mocker, kind: .m1_computedInt, assertion: assertion)
                     }
-                    var computedString: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var computedString: FunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m2_computedString, assertion: assertion)
                     }
                 }
@@ -351,13 +351,13 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    var throwingProperty: ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    var throwingProperty: ThrowingFunctionActionBuilder<MockTest, ActionBuilder, Int> {
                         .init(mocker, kind: .m1_throwingProperty)
                     }
-                    var asyncProperty: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var asyncProperty: FunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m2_asyncProperty)
                     }
-                    var asyncThrowingProperty: ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    var asyncThrowingProperty: ThrowingFunctionActionBuilder<MockTest, ActionBuilder, String> {
                         .init(mocker, kind: .m3_asyncThrowingProperty)
                     }
                 }
@@ -368,13 +368,13 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var throwingProperty: ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var throwingProperty: ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder, Int> {
                         .init(mocker, kind: .m1_throwingProperty, assertion: assertion)
                     }
-                    var asyncProperty: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var asyncProperty: FunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m2_asyncProperty, assertion: assertion)
                     }
-                    var asyncThrowingProperty: ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var asyncThrowingProperty: ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder, String> {
                         .init(mocker, kind: .m3_asyncThrowingProperty, assertion: assertion)
                     }
                 }


### PR DESCRIPTION
This PR fixes a problem when functions in a protocol had the same name and params but different return types, as discussed in https://github.com/Kolos65/Mockable/issues/13