### PR TITLE
[WIP] Add scripts to build and test the package in a Linux container

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           swift-version: '5.9'
 
-      - name: Build for release
+      - name: Build
         run: |
           Scripts/build.sh
   test:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,9 +6,30 @@ on:
       - '*'
 
 jobs:
+  build:
+    name: Release build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-13]
+    steps:          
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '5.9'
+
+      - name: Build for release
+        run: |
+          Scripts/build.sh
   test:
-    name: Build Package and Run Tests
-    runs-on: macOS-13
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-13]
     steps:          
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Scripts/build-in-docker.sh
+++ b/Scripts/build-in-docker.sh
@@ -8,4 +8,4 @@ docker run --rm \
     -e MOCKABLE_DEV='false' \
     swift:5.9 \
     /bin/bash -c \
-    "swift package fetch && swift build --configuration release"
+    "swift package fetch && swift build release"

--- a/Scripts/build-in-docker.sh
+++ b/Scripts/build-in-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eo pipefail
+
+docker run --rm \
+    --volume "$(pwd):/package" \
+    --workdir "/package" \
+    -e MOCKABLE_DEV='false' \
+    swift:5.9 \
+    /bin/bash -c \
+    "swift package fetch && swift build --configuration release"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eo pipefail
+
+export MOCKABLE_DEV=false
+swift build --configuration release

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -3,4 +3,4 @@
 set -eo pipefail
 
 export MOCKABLE_DEV=false
-swift build --configuration release
+swift build

--- a/Scripts/test-in-docker.sh
+++ b/Scripts/test-in-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eo pipefail
+
+docker run --rm \
+    --volume "$(pwd):/package" \
+    --workdir "/package" \
+    -e MOCKABLE_DEV='true' \
+    swift:5.9 \
+    /bin/bash -c \
+    "swift package fetch && swift test"

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -2,8 +2,5 @@
 
 set -eo pipefail
 
-export MOCKABLE_DEV=false
-swift build
-
 export MOCKABLE_DEV=true
 swift test


### PR DESCRIPTION
I tried to use Mockable from Ubuntu and I noticed that it fails to compile because it uses some macOS-only API. This PR tries to address that plus:
- Extends the CI pipelines to run on `ubuntu-latest`
- Splits the workflow to build and test in two separate workflows. That way, they run in parallel and can be retried independently.
- Adds a couple of scripts to build and test the project in a Linux environment using Docker.