### PR TITLE
Add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,34 @@ If you see an error during tests like:
 
 Remember to add the noted type to your `Matcher` using the `register()` function.
 
+## Strict Mode
+Mockable supports a strict mode which requires every optional property and void returning member to be mocked instead of implicitly returning nil or just running.
+This can be enabled by calling the `init(strict: Bool)` constructor of the mock.
+
+Here is an example how to do this:
+```swift
+func testProductService_strict() async throws {
+    let productService = MockProductService(strict: true)
+
+    // given(productService)
+    //     .url.willReturn(nil)
+
+    // This will throw a fatal error in strict mode, 
+    // as the result of url is not mocked
+    XCTAssertNil(productService.url)
+
+    // given(productService)
+    //     .checkout(with: .any)
+    //     .justRuns()
+
+    // This will throw a fatal error in strict mode,
+    // as the method call was not mocked.
+    productSerivce.checkout(with: Product(name: "iPhone 15 Pro"))
+}
+```
+
+Mocking methods returning void can be done by calling `.willReturn(())` or by using the shorthand `.justRuns()`.
+
 ## Supported Features
 
 - [x] **Zero-boilerplate** mock generation</br>

--- a/Sources/Mockable/Builder/FunctionBuilders/FunctionReturnBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/FunctionReturnBuilder.swift
@@ -50,3 +50,10 @@ public struct FunctionReturnBuilder<T: Mockable, ParentBuilder: EffectBuilder<T>
         return .init(mocker: mocker)
     }
 }
+
+extension FunctionReturnBuilder where ReturnType == () {
+    @discardableResult
+    public func justRuns() -> ParentBuilder {
+        willReturn(())
+    }
+}

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
@@ -60,3 +60,10 @@ public struct ThrowingFunctionReturnBuilder<T: Mockable, ParentBuilder: EffectBu
         return .init(mocker: mocker)
     }
 }
+
+extension ThrowingFunctionReturnBuilder where ReturnType == () {
+    @discardableResult
+    public func justRuns() -> ParentBuilder {
+        willReturn(())
+    }
+}

--- a/Sources/MockableMacro/Generator/Members/InitConformances.swift
+++ b/Sources/MockableMacro/Generator/Members/InitConformances.swift
@@ -35,19 +35,27 @@ struct InitConformances {
         }
         let hasDefault = inits.contains {
             $0.signature.effectSpecifiers == nil
-            && $0.signature.parameterClause.parameters.isEmpty
-            && $0.optionalMark == nil
-            && $0.genericWhereClause == nil
-            && $0.genericParameterClause == nil
+                && $0.signature.parameterClause.parameters.isEmpty
+                && $0.optionalMark == nil
+                && $0.genericWhereClause == nil
+                && $0.genericParameterClause == nil
         }
+        let strictInit = InitializerDeclSyntax(
+            modifiers: protocolDeclaration.modifiers,
+            signature: .init(parameterClause: .init(parameters: [.init(
+                firstName: "strict",
+                type: IdentifierTypeSyntax(name: "Bool")
+            )])),
+            body: .init(statements: [.init(stringLiteral: "mocker.strict = strict")])
+        )
         guard hasDefault else {
             let defaultInit = InitializerDeclSyntax(
                 modifiers: protocolDeclaration.modifiers,
                 signature: .init(parameterClause: .init(parameters: [])),
                 body: .init(statements: [])
             )
-            return initConformances + [.init(decl: defaultInit)]
+            return initConformances + [.init(decl: defaultInit), .init(decl: strictInit)]
         }
-        return initConformances
+        return initConformances + [.init(decl: strictInit)]
     }
 }

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -45,6 +45,9 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func foo(item: Item) -> Item {
                     let member: Member = .m1_foo(item: .value(item))
                     return try! mocker.mock(member) { producer in
@@ -133,6 +136,9 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func foo(item: Item) -> Item {
                     let member: Member = .m1_foo(item: .value(item))
                     return try! mocker.mock(member) { producer in
@@ -220,6 +226,9 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 func foo(item: Item) -> Item {
                     let member: Member = .m1_foo(item: .value(item))

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -43,6 +43,9 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func modifyValue(_ value: inout Int) {
                     let member: Member = .m1_modifyValue(.value(value))
                     try! mocker.mock(member) { producer in
@@ -129,6 +132,9 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func printValues(_ values: Int...) {
                     let member: Member = .m1_printValues(.value(values))
                     try! mocker.mock(member) { producer in
@@ -214,6 +220,9 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 func execute(operation: @escaping () throws -> Void) {
                     let member: Member = .m1_execute(operation: .value(operation))

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -46,6 +46,9 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func returnsAndThrows() throws -> String {
                     let member: Member = .m1_returnsAndThrows
                     return try mocker.mock(member) { producer in
@@ -152,6 +155,9 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func execute(operation: @escaping () throws -> Void) rethrows {
                     let member: Member = .m1_execute(operation: .value(operation))
                     try! mocker.mock(member) { producer in
@@ -241,6 +247,9 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 func asyncFunction() async {
                     let member: Member = .m1_asyncFunction

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -43,6 +43,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func foo<T>(item: (Array<[(Set<T>, String)]>, Int)) {
                     let member: Member = .m1_foo(item: .generic(item))
                     try! mocker.mock(member) { producer in
@@ -128,6 +131,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 func genericFunc<T, V>(item: T) -> V {
                     let member: Member = .m1_genericFunc(item: .generic(item))
@@ -218,6 +224,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 func method1<T: Hashable, E, C, I>(
                         p1: T, p2: E, p3: C, p4: I

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -47,6 +47,9 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name: String) {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 enum Member: Matchable, CaseIdentifiable {
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -126,6 +129,9 @@ final class InitRequirementTests: MockableMacroTestCase {
                 init(name value: String, _ index: Int) {
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 enum Member: Matchable, CaseIdentifiable {
                     func match(_ other: Member) -> Bool {

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -45,6 +45,9 @@ final class NameCollisionTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 func fetchData(for name: Int) -> String {
                     let member: Member = .m1_fetchData(for: .value(name))
                     return try! mocker.mock(member) { producer in
@@ -152,6 +155,9 @@ final class NameCollisionTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 func fetchData(forA name: String) -> String {
                     let member: Member = .m1_fetchData(forA: .value(name))

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -45,6 +45,9 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 }
                 init() {
                 }
+                init(strict: Bool) {
+                    mocker.strict = strict
+                }
                 var computedInt: Int {
                     get {
                         let member: Member = .m1_computedInt
@@ -156,6 +159,9 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 var mutableInt: Int {
                     get {
@@ -286,6 +292,9 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     mocker.reset(scopes: scopes)
                 }
                 init() {
+                }
+                init(strict: Bool) {
+                    mocker.strict = strict
                 }
                 var throwingProperty: Int {
                     get throws {

--- a/Tests/MockableTests/Protocols/UserService.swift
+++ b/Tests/MockableTests/Protocols/UserService.swift
@@ -19,6 +19,7 @@ protocol UserService {
     // MARK: Properties
 
     var name: String { get set }
+    var optional: String? { get set }
 
     // MARK: Functions
 

--- a/Tests/MockableTests/UnitTests/GivenTests.swift
+++ b/Tests/MockableTests/UnitTests/GivenTests.swift
@@ -250,4 +250,49 @@ final class GivenTests: XCTestCase {
 
         XCTAssertEqual(result, 1234)
     }
+
+    func test_givenStrictVoidFunc() throws {
+        let mock = MockUserService<String>(strict: true)
+        given(mock)
+            .print()
+            .justRuns()
+
+        try mock.print()
+
+        verify(mock)
+            .print()
+            .called(count: 1)
+    }
+
+//    This test should throw a fatal error. Fatal errors are notoriously hard to catch.
+//    func test_givenStrictVoidFunc_missing_mock() throws {
+//        let mock = MockUserService<String>(strict: true)
+//
+//        try mock.print()
+//
+//        verify(mock)
+//            .print()
+//            .called(count: 1)
+//    }
+
+    func test_givenNonStrictOptional() throws {
+        let mock = MockUserService<String>()
+
+        XCTAssertNil(mock.optional)
+
+        verify(mock)
+            .optional()
+            .getterCalled(count: 1)
+    }
+
+//    This test should throw a fatal error. Fatal errors are notoriously hard to catch.
+//    func test_givenStrictOptional() throws {
+//        let mock = MockUserService<String>(strict: true)
+//
+//        XCTAssertNil(mock.optional)
+//
+//        verify(mock)
+//            .optional()
+//            .getterCalled(count: 1)
+//    }
 }


### PR DESCRIPTION
This PR implements strict mode and lenient mode as outlined in #15.

It adds an additional constructor to the generated mock classes that allows for (optionally) switching to strict mode.
```swift
let mockService = MockService(strict: true)
```

When in strict mode the following now is in effect:
1. Methods returning void now have to be mocked
2. Properties returning an optional type have to be mocked (this is the same as it is right now)

In lenient mode (without using the new constructor or by passing false), the following behavior is in effect:
1. Methods returning void do not have to be mocked and will always run (the current behavior)
2. Properties returning an optional will automatically return nil

Even though the lenient mode is currently implemented as default, this could be changed (I would love to have strict mode as default). I still chose to go for lenient as the default, as this is a breaking change that is less likely to be problematic for existing users.

I hope this can be merged and introduced in a new version.
I suggest to warn users in the changelog about the differing behavior for optional properties returning nil by default.

I have updated the README to include an explaining section about strict mode.