### PR TITLE
feat: require explicit mocking of void functions

### DIFF
--- a/Sources/Mockable/Builder/FunctionBuilders/FunctionReturnBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/FunctionReturnBuilder.swift
@@ -50,3 +50,12 @@ public struct FunctionReturnBuilder<T: Mockable, ParentBuilder: EffectBuilder<T>
         return .init(mocker: mocker)
     }
 }
+
+extension FunctionReturnBuilder where ReturnType == Void {
+    /// Specifies that the void function will return normally when the mocked member is called.
+    @discardableResult
+    public func willReturn() -> ParentBuilder {
+        mocker.given(member, returnValue: .return(()))
+        return .init(mocker: mocker)
+    }
+}

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
@@ -60,3 +60,12 @@ public struct ThrowingFunctionReturnBuilder<T: Mockable, ParentBuilder: EffectBu
         return .init(mocker: mocker)
     }
 }
+
+extension ThrowingFunctionReturnBuilder where ReturnType == Void {
+    /// Specifies that the void function will return normally when the mocked member is called.
+    @discardableResult
+    public func willReturn() -> ParentBuilder {
+        mocker.given(member, returnValue: .return(()))
+        return .init(mocker: mocker)
+    }
+}

--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -117,22 +117,6 @@ public class Mocker<T: Mockable> {
     public func mock<V>(_ member: Member, producerResolver: (Any) throws -> V) throws -> V {
         return try tryMock(member: member, producerResolver: producerResolver)
     }
-
-    /// Mocks a void member, performing associated actions.
-    ///
-    /// - Parameters:
-    ///   - member: The member to mock.
-    ///   - producerResolver: A closure resolving the produced value.
-    /// - Throws: An error if the mock encounters an issue.
-    public func mock(
-        _ member: Member, producerResolver: (Any) throws -> Void
-    ) throws {
-        return try tryMock(
-            member: member,
-            producerResolver: producerResolver,
-            fallback: .value(())
-        )
-    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
As @xmanu pointed out in #15 and proposed in #25 the current implementation does not require the explicit mocking of void functions. This makes the current implementation inconsistent as it otherwise requires explicit mocking for every other member.

This PR addresses this issue and makes the implementation consistent by requiring explicit mocking for void functions too. In addition, it adds a helper that makes it possible to write:

```swift
given(mock).someVoidFunc().willReturn()
```
instead of:
```swift
given(mock).someVoidFunc().willReturn(())
```

Support for an opt-in "relaxed mode" could be added in the future which would eliminate the need for explicit mocking in case of return values expressible by some literal (like optionals).