### PR TITLE
Relaxed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [Given](#Given)
   - [When](#When)
   - [Verify](#Verify)
+  - [Relaxed Mode](#Relaxed-Mode)
   - [Non-equatable Types](#Working-with-non-equatable-Types)
 - [Supported Features](#Supported-Features)
 - [Limitations](#Limitations)
@@ -257,6 +258,30 @@ verify(productService)
     // assert url property was never set to nil
     .url(newValue: .value(nil)).setterCalled(count: .never)
 ```
+
+### Relaxed Mode
+By default, you must specify a return value for all requirements; otherwise, a fatal error will be thrown. The reason for this is to aid in the discovery (and thus the verification) of every called function when writing unit tests. 
+
+However, it is common to prefer avoiding this strict default behavior in favor of a more relaxed setting, where, 
+for example, void or optional return values do not need explicit `given` registration.
+
+Use the **MockerPolicy** [option set](https://developer.apple.com/documentation/swift/optionset) to implicitly mock:
+* only one kind of return value: `.relaxedOptional`
+* construct a custom set of policies: `[.relaxedVoid, .relaxedOptional, .relaxedArray]`
+* or opt for a fully relaxed mode: `.relaxed`.
+
+You have two options to override the default strict behavior of the library:
+* at **mock implementation level** you can override the mocker policy for each individual mock implementation in the initializer: 
+    ```swift
+    let relaxedMock = MockService(policy: [.relaxedOptional, .relaxedVoid])
+    ```
+* at **project level** you can set a custom default policy to use in every scenario by changing the default property of **MockerPolicy**: 
+    ```swift
+    MockerPolicy.default = .relaxedVoid
+    ```
+
+> ⚠️ Relaxed mode will not work with generic functions as the type system is unable to locate the appropriate generic overload.
+
 
 ### Working with non-equatable Types
 **Mockable** uses a `Matcher` internally to compare parameters. 

--- a/Sources/Mockable/Documentation/Documentation.docc/Usage.md
+++ b/Sources/Mockable/Documentation/Documentation.docc/Usage.md
@@ -159,6 +159,30 @@ verify(productService)
     .url(newValue: .value(nil)).setterCalled(count: .never)
 ```
 
+## Relaxed Mode
+By default, you must specify a return value for all requirements; otherwise, a fatal error will be thrown. The reason for this is to aid in the discovery (and thus the verification) of every called function when writing unit tests. 
+
+However, it is common to prefer avoiding this strict default behavior in favor of a more relaxed setting, where, 
+for example, void or optional return values do not need explicit `given` registration.
+
+Use the **MockerPolicy** [option set](https://developer.apple.com/documentation/swift/optionset) to implicitly mock:
+* only one kind of return value: `.relaxedOptional`
+* construct a custom set of policies: `[.relaxedVoid, .relaxedOptional, .relaxedArray]`
+* or opt for a fully relaxed mode: `.relaxed`.
+
+You have two options to override the default strict behavior of the library:
+* At **mock implementation level** you can override the mocker policy for each individual mock implementation in the initializer: 
+    ```swift
+    let relaxedMock = MockService(policy: [.relaxedOptional, .relaxedVoid])
+    ```
+* At **project level** you can set a custom default policy to use in every scenario by changing the default property of **MockerPolicy**: 
+    ```swift
+    MockerPolicy.default = .relaxedVoid
+    ```
+
+> ⚠️ Relaxed mode will not work with generic functions as the type system is unable to locate the appropriate generic overload.
+
+
 ## Working with non-equatable Types
 **Mockable** uses a `Matcher` internally to compare parameters. 
 By default the matcher is able to compare any custom type that conforms to `Equatable` (except when used in a generic function).

--- a/Sources/Mockable/Mocker/MockerPolicy.swift
+++ b/Sources/Mockable/Mocker/MockerPolicy.swift
@@ -1,0 +1,70 @@
+//
+//  MockerPolicy.swift
+//  Mockable
+//
+//  Created by Kolos Foltanyi on 2024. 04. 01..
+//
+
+/// A policy that controls how the library handles when no return value is found during mocking.
+///
+/// MockerPolicy can be used to customize mocking behavior and disable the requirement of
+/// return value registration in case of built in types (like Void).
+public struct MockerPolicy: OptionSet {
+    /// Default policy to use when none was explicitly specified for a mock.
+    ///
+    /// Change this property to set the default policy to use for all mocks. Defaults to `strict`.
+    public static var `default`: Self = .strict
+
+    /// All return values must be registered, a fatal error will occur otherwise.
+    public static let strict: Self = []
+
+    /// Every literal expressible requirement will return a default value.
+    public static let relaxed: Self = [
+        .relaxedOptional,
+        .relaxedThrowingVoid,
+        .relaxedNonThrowingVoid,
+        .relaxedInteger,
+        .relaxedBoolean,
+        .relaxedArray,
+        .relaxedDictionary,
+        .relaxedString
+    ]
+
+    /// Every void function will run normally without a registration
+    public static let relaxedVoid: Self = [
+        .relaxedNonThrowingVoid,
+        .relaxedThrowingVoid
+    ]
+
+    /// Throwing Void functions will run without return value registration.
+    public static let relaxedThrowingVoid = Self(rawValue: 1 << 1)
+
+    /// Non-throwing Void functions will run without return value registration.
+    public static let relaxedNonThrowingVoid = Self(rawValue: 1 << 2)
+
+    /// Optional return values will default to nil.
+    public static let relaxedOptional = Self(rawValue: 1 << 0)
+
+    /// Integer expressible return values will default to 1.
+    public static let relaxedInteger = Self(rawValue: 1 << 3)
+
+    /// String literal expressible return values will default to an empty string.
+    public static let relaxedString = Self(rawValue: 1 << 4)
+
+    /// Integer expressible return values will default to true.
+    public static let relaxedBoolean = Self(rawValue: 1 << 5)
+
+    /// Array expressible return values will default to an empty array.
+    public static let relaxedArray = Self(rawValue: 1 << 6)
+
+    /// Dictionary expressible return values will default to an empty dictionary.
+    public static let relaxedDictionary = Self(rawValue: 1 << 7)
+
+    /// Option set raw value.
+    public let rawValue: Int
+
+    /// Creates a new option set from the given raw value.
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -35,10 +35,12 @@ enum NS {
     static let initializer: TokenSyntax = "init"
     static let member: TokenSyntax = "member"
     static let mock: TokenSyntax = "mock"
+    static let mockThrowing: TokenSyntax = "mockThrowing"
     static let producer: TokenSyntax = "producer"
     static let cast: TokenSyntax = "cast"
     static let addInvocation: TokenSyntax = "addInvocation"
     static let performActions: TokenSyntax = "performActions"
+    static let policy: TokenSyntax = "policy"
 
     static let _andSign: String = "&&"
     static let _init: TokenSyntax = "init"
@@ -65,6 +67,7 @@ enum NS {
     static let ActionBuilder: TokenSyntax = "ActionBuilder"
     static let VerifyBuilder: TokenSyntax = "VerifyBuilder"
     static let MockerScope: TokenSyntax = "MockerScope"
+    static let MockerPolicy: TokenSyntax = "MockerPolicy"
     static let Set: TokenSyntax = "Set"
     static let Void: TokenSyntax = "Void"
 

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -43,11 +43,14 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func foo(item: Item) -> Item {
                     let member: Member = .m1_foo(item: .value(item))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (Item) -> Item
                         return producer(item)
                     }
@@ -130,11 +133,14 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func foo(item: Item) -> Item {
                     let member: Member = .m1_foo(item: .value(item))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (Item) -> Item
                         return producer(item)
                     }
@@ -217,11 +223,14 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func foo(item: Item) -> Item {
                     let member: Member = .m1_foo(item: .value(item))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (Item) -> Item
                         return producer(item)
                     }

--- a/Tests/MockableMacroTests/AttributesTests.swift
+++ b/Tests/MockableMacroTests/AttributesTests.swift
@@ -67,7 +67,10 @@ final class AttributesTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 @available(iOS 15, *)
                 init(name: String) {
@@ -78,7 +81,7 @@ final class AttributesTests: MockableMacroTestCase {
                 @available(iOS 15, *)
                 func test() {
                     let member: Member = .m3_test
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as () -> Void
                         return producer()
                     }
@@ -86,7 +89,7 @@ final class AttributesTests: MockableMacroTestCase {
                 @available(iOS 15, *)
                 func test2() {
                     let member: Member = .m4_test2
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as () -> Void
                         return producer()
                     }
@@ -95,7 +98,7 @@ final class AttributesTests: MockableMacroTestCase {
                 var prop: Int {
                     get {
                         let member: Member = .m1_prop
-                        return try! mocker.mock(member) { producer in
+                        return mocker.mock(member) { producer in
                             let producer = try cast(producer) as () -> Int
                             return producer()
                         }
@@ -105,7 +108,7 @@ final class AttributesTests: MockableMacroTestCase {
                 var prop2: Int {
                     get {
                         let member: Member = .m2_prop2
-                        return try! mocker.mock(member) { producer in
+                        return mocker.mock(member) { producer in
                             let producer = try cast(producer) as () -> Int
                             return producer()
                         }

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -41,11 +41,14 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func modifyValue(_ value: inout Int) {
                     let member: Member = .m1_modifyValue(.value(value))
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as (Int) -> Void
                         return producer(value)
                     }
@@ -126,11 +129,14 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func printValues(_ values: Int...) {
                     let member: Member = .m1_printValues(.value(values))
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as ([Int]) -> Void
                         return producer(values)
                     }
@@ -211,11 +217,14 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func execute(operation: @escaping () throws -> Void) {
                     let member: Member = .m1_execute(operation: .value(operation))
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as (() throws -> Void) -> Void
                         return producer(operation)
                     }

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -44,18 +44,21 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func returnsAndThrows() throws -> String {
                     let member: Member = .m1_returnsAndThrows
-                    return try mocker.mock(member) { producer in
+                    return try mocker.mockThrowing(member) { producer in
                         let producer = try cast(producer) as () throws -> String
                         return try producer()
                     }
                 }
                 func canThrowError() throws {
                     let member: Member = .m2_canThrowError
-                    try mocker.mock(member) { producer in
+                    try mocker.mockThrowing(member) { producer in
                         let producer = try cast(producer) as () throws -> Void
                         return try producer()
                     }
@@ -150,11 +153,14 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func execute(operation: @escaping () throws -> Void) rethrows {
                     let member: Member = .m1_execute(operation: .value(operation))
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as (() throws -> Void) -> Void
                         return producer(operation)
                     }
@@ -239,25 +245,28 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func asyncFunction() async {
                     let member: Member = .m1_asyncFunction
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as () -> Void
                         return producer()
                     }
                 }
                 func asyncThrowingFunction() async throws {
                     let member: Member = .m2_asyncThrowingFunction
-                    try mocker.mock(member) { producer in
+                    try mocker.mockThrowing(member) { producer in
                         let producer = try cast(producer) as () throws -> Void
                         return try producer()
                     }
                 }
                 func asyncParamFunction(param: @escaping () async throws -> Void) async throws {
                     let member: Member = .m3_asyncParamFunction(param: .value(param))
-                    try mocker.mock(member) { producer in
+                    try mocker.mockThrowing(member) { producer in
                         let producer = try cast(producer) as (() async throws -> Void) throws -> Void
                         return try producer(param)
                     }

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -41,11 +41,14 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func foo<T>(item: (Array<[(Set<T>, String)]>, Int)) {
                     let member: Member = .m1_foo(item: .generic(item))
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as ((Array<[(Set<T>, String)]>, Int)) -> Void
                         return producer(item)
                     }
@@ -126,11 +129,14 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func genericFunc<T, V>(item: T) -> V {
                     let member: Member = .m1_genericFunc(item: .generic(item))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (T) -> V
                         return producer(item)
                     }
@@ -215,14 +221,17 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func method1<T: Hashable, E, C, I>(
                         p1: T, p2: E, p3: C, p4: I
                     ) where E: Equatable, E: Hashable, C: Codable {
                     let member: Member = .m1_method1(p1: .generic(
                             p1), p2: .generic(p2), p3: .generic(p3), p4: .generic(p4))
-                    try! mocker.mock(member) { producer in
+                    mocker.mock(member) { producer in
                         let producer = try cast(producer) as (T, E, C, I) -> Void
                         return producer(p1, p2, p3, p4)
                     }

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -43,6 +43,11 @@ final class InitRequirementTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
+                }
                 init() {
                 }
                 init(name: String) {
@@ -115,7 +120,10 @@ final class InitRequirementTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 init?() async throws {
                 }

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -43,18 +43,21 @@ final class NameCollisionTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func fetchData(for name: Int) -> String {
                     let member: Member = .m1_fetchData(for: .value(name))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (Int) -> String
                         return producer(name)
                     }
                 }
                 func fetchData(for name: String) -> String {
                     let member: Member = .m2_fetchData(for: .value(name))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (String) -> String
                         return producer(name)
                     }
@@ -151,18 +154,21 @@ final class NameCollisionTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 func fetchData(forA name: String) -> String {
                     let member: Member = .m1_fetchData(forA: .value(name))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (String) -> String
                         return producer(name)
                     }
                 }
                 func fetchData(forB name: String) -> String {
                     let member: Member = .m2_fetchData(forB: .value(name))
-                    return try! mocker.mock(member) { producer in
+                    return mocker.mock(member) { producer in
                         let producer = try cast(producer) as (String) -> String
                         return producer(name)
                     }

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -43,12 +43,15 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 var computedInt: Int {
                     get {
                         let member: Member = .m1_computedInt
-                        return try! mocker.mock(member) { producer in
+                        return mocker.mock(member) { producer in
                             let producer = try cast(producer) as () -> Int
                             return producer()
                         }
@@ -57,7 +60,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 var computedString: String! {
                     get {
                         let member: Member = .m2_computedString
-                        return try! mocker.mock(member) { producer in
+                        return mocker.mock(member) { producer in
                             let producer = try cast(producer) as () -> String
                             return producer()
                         }
@@ -155,12 +158,15 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 var mutableInt: Int {
                     get {
                         let member: Member = .m1_get_mutableInt
-                        return try! mocker.mock(member) { producer in
+                        return mocker.mock(member) { producer in
                             let producer = try cast(producer) as () -> Int
                             return producer()
                         }
@@ -174,7 +180,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 var mutableString: String {
                     get {
                         let member: Member = .m2_get_mutableString
-                        return try! mocker.mock(member) { producer in
+                        return mocker.mock(member) { producer in
                             let producer = try cast(producer) as () -> String
                             return producer()
                         }
@@ -285,12 +291,15 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 func reset(_ scopes: Set<MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init() {
+                init(policy: MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
                 }
                 var throwingProperty: Int {
                     get throws {
                         let member: Member = .m1_throwingProperty
-                        return try mocker.mock(member) { producer in
+                        return try mocker.mockThrowing(member) { producer in
                             let producer = try cast(producer) as () throws -> Int
                             return try producer()
                         }
@@ -299,7 +308,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 var asyncProperty: String {
                     get async {
                         let member: Member = .m2_asyncProperty
-                        return try! mocker.mock(member) { producer in
+                        return mocker.mock(member) { producer in
                             let producer = try cast(producer) as () -> String
                             return producer()
                         }
@@ -308,7 +317,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 var asyncThrowingProperty: String {
                     get async throws {
                         let member: Member = .m3_asyncThrowingProperty
-                        return try mocker.mock(member) { producer in
+                        return try mocker.mockThrowing(member) { producer in
                             let producer = try cast(producer) as () throws -> String
                             return try producer()
                         }

--- a/Tests/MockableTests/UnitTests/GivenTests.swift
+++ b/Tests/MockableTests/UnitTests/GivenTests.swift
@@ -12,7 +12,7 @@ final class GivenTests: XCTestCase {
 
     // MARK: Properties
 
-    private let mock = MockTestService<String>()
+    private var mock = MockTestService<String>()
 
     // MARK: Overrides
 

--- a/Tests/MockableTests/UnitTests/PolicyTests.swift
+++ b/Tests/MockableTests/UnitTests/PolicyTests.swift
@@ -1,0 +1,115 @@
+//
+//  PolicyTests.swift
+//  
+//
+//  Created by Kolos Foltanyi on 2024. 04. 02..
+//
+
+import XCTest
+import MockableTest
+
+@Mockable
+protocol PolicyService {
+    func throwingVoidFunc() throws
+    var throwingVoidProp: Void { get throws }
+    func nonThrowingVoidFunc()
+    var nonThrowingVoidProp: Void { get }
+    func optionalFunc() -> String?
+    var optionalProp: String? { get }
+    func integerFunc() -> Int
+    var integerProp: Int { get }
+    func floatFunc() -> Float
+    var floatProp: Float { get }
+    func booleanFunc() -> Bool
+    var booleanProp: Bool { get }
+    func arrayFunc() -> [String]
+    var arrayProp: [String] { get }
+    func dictionaryFunc() -> [String: String]
+    var dictionaryProp: [String: String] { get }
+    func stringFunc() -> String
+    var stringProp: String { get }
+}
+
+final class PolicyTests: XCTestCase {
+
+    // MARK: Overrides
+
+    override func tearDown() {
+        Matcher.reset()
+        MockerPolicy.default = .strict
+    }
+
+    // MARK: Tests
+
+    func test_whenDefaultPolicyChanged_allCallsAreRelaxed() throws {
+        let mock = MockPolicyService()
+        MockerPolicy.default = .relaxed
+        try testRelaxed(on: mock)
+    }
+
+    func test_whenCustomRelaxedPolicySet_allCallsAreRelaxed() throws {
+        let mock = MockPolicyService(policy: .relaxed)
+        try testRelaxed(on: mock)
+    }
+
+    func test_whenCustomVoidPolicySet_mockReturnsDefault() throws {
+        let mock = MockPolicyService(policy: .relaxedVoid)
+        try mock.throwingVoidFunc()
+        try mock.throwingVoidProp
+        mock.nonThrowingVoidFunc()
+        mock.nonThrowingVoidProp
+    }
+
+    func test_whenCustomIntPolicySet_mockReturnsDefault() throws {
+        let mock = MockPolicyService(policy: .relaxedInteger)
+        XCTAssertEqual(1, mock.integerFunc())
+        XCTAssertEqual(1, mock.integerProp)
+        XCTAssertEqual(1, mock.floatFunc())
+        XCTAssertEqual(1, mock.floatProp)
+    }
+
+    func test_whenCustomBoolPolicySet_mockReturnsDefault() throws {
+        let mock = MockPolicyService(policy: .relaxedBoolean)
+        XCTAssertEqual(true, mock.booleanFunc())
+        XCTAssertEqual(true, mock.booleanProp)
+    }
+
+    func test_whenCustomArrayPolicySet_mockReturnsDefault() throws {
+        let mock = MockPolicyService(policy: .relaxedArray)
+        XCTAssertEqual([], mock.arrayFunc())
+        XCTAssertEqual([], mock.arrayProp)
+    }
+
+    func test_whenCustomDictionaryPolicySet_mockReturnsDefault() throws {
+        let mock = MockPolicyService(policy: .relaxedDictionary)
+        XCTAssertEqual([:], mock.dictionaryFunc())
+        XCTAssertEqual([:], mock.dictionaryProp)
+    }
+
+    func test_whenCustomStringPolicySet_mockReturnsDefault() throws {
+        let mock = MockPolicyService(policy: .relaxedString)
+        XCTAssertEqual("", mock.stringFunc())
+        XCTAssertEqual("", mock.stringProp)
+    }
+
+    private func testRelaxed(on service: MockPolicyService) throws {
+        try service.throwingVoidFunc()
+        try service.throwingVoidProp
+        service.nonThrowingVoidFunc()
+        service.nonThrowingVoidProp
+        XCTAssertEqual(nil, service.optionalFunc())
+        XCTAssertEqual(nil, service.optionalProp)
+        XCTAssertEqual(1, service.integerFunc())
+        XCTAssertEqual(1, service.integerProp)
+        XCTAssertEqual(1, service.floatFunc())
+        XCTAssertEqual(1, service.floatProp)
+        XCTAssertEqual(true, service.booleanFunc())
+        XCTAssertEqual(true, service.booleanProp)
+        XCTAssertEqual([], service.arrayFunc())
+        XCTAssertEqual([], service.arrayProp)
+        XCTAssertEqual([:], service.dictionaryFunc())
+        XCTAssertEqual([:], service.dictionaryProp)
+        XCTAssertEqual("", service.stringFunc())
+        XCTAssertEqual("", service.stringProp)
+    }
+}


### PR DESCRIPTION
## Relaxed Mode
By default, you must specify a return value for all requirements; otherwise, a fatal error will be thrown. The reason for this is to aid in the discovery (and thus the verification) of every called function when writing unit tests. 

However, it is common to prefer avoiding this strict default behavior in favor of a more relaxed setting, where, 
for example, void or optional return values do not need explicit `given` registration.

Use the **MockerPolicy** [option set](https://developer.apple.com/documentation/swift/optionset) to implicitly mock:
* only one kind of return value: `.relaxedOptional`
* construct a custom set of policies: `[.relaxedVoid, .relaxedOptional, .relaxedArray]`
* or opt for a fully relaxed mode: `.relaxed`.

You have two options to override the default strict behavior of the library:
* At **mock implementation level** you can override the mocker policy for each individual mock implementation in the initializer: 
    ```swift
    let relaxedMock = MockService(policy: [.relaxedOptional, .relaxedVoid])
    ```
* At **project level** you can set a custom default policy to use in every scenario by changing the default property of **MockerPolicy**: 
    ```swift
    MockerPolicy.default = .relaxedVoid
    ```

> ⚠️ Relaxed mode will not work with generic functions as the type system is unable to locate the appropriate generic overload.
