### PR TITLE
feat: rename MockService to MockableService to avoid name collision

### DIFF
--- a/Sources/Mockable/Builder/EffectBuilder.swift
+++ b/Sources/Mockable/Builder/EffectBuilder.swift
@@ -10,7 +10,7 @@
 public protocol EffectBuilder<Service> {
 
     /// The mock service associated with the Builder.
-    associatedtype Service: MockService
+    associatedtype Service: MockableService
 
     /// Initializes a new instance of the builder with the provided `Mocker`.
     ///

--- a/Sources/Mockable/Builder/FunctionBuilders/FunctionActionBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/FunctionActionBuilder.swift
@@ -9,7 +9,7 @@
 ///
 /// This builder is used within the context of a higher-level builder (e.g., an `ActionBuilder`)
 /// to specify a desired action to perform when a particular function of a mock service is called.
-public struct FunctionActionBuilder<T: MockService, ParentBuilder: EffectBuilder<T>> {
+public struct FunctionActionBuilder<T: MockableService, ParentBuilder: EffectBuilder<T>> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/FunctionBuilders/FunctionReturnBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/FunctionReturnBuilder.swift
@@ -9,7 +9,7 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., a `ReturnBuilder`)
 /// to specify the desired return value or a return value producer for a particular function of a mock service.
-public struct FunctionReturnBuilder<T: MockService, ParentBuilder: EffectBuilder<T>, ReturnType, ProduceType> {
+public struct FunctionReturnBuilder<T: MockableService, ParentBuilder: EffectBuilder<T>, ReturnType, ProduceType> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/FunctionBuilders/FunctionVerifyBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/FunctionVerifyBuilder.swift
@@ -9,7 +9,7 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., a `VerifyBuilder`)
 /// to verify the expected number of invocations for a particular function of a mock service.
-public struct FunctionVerifyBuilder<T: MockService, ParentBuilder: AssertionBuilder<T>> {
+public struct FunctionVerifyBuilder<T: MockableService, ParentBuilder: AssertionBuilder<T>> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionActionBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionActionBuilder.swift
@@ -9,5 +9,5 @@
 ///
 /// This builder is used within the context of a higher-level builder (e.g., an `ActionBuilder`)
 /// to specify a desired action to perform when a particular throwing function of a mock service is called.
-public typealias ThrowingFunctionActionBuilder<T: MockService, ParentBuilder: EffectBuilder<T>>
+public typealias ThrowingFunctionActionBuilder<T: MockableService, ParentBuilder: EffectBuilder<T>>
     = FunctionActionBuilder<T, ParentBuilder>

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
@@ -9,7 +9,12 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., a `ReturnBuilder`)
 /// to specify the desired return value or a return value producer for a throwing function of a mock service.
-public struct ThrowingFunctionReturnBuilder<T: MockService, ParentBuilder: EffectBuilder<T>, ReturnType, ProduceType> {
+public struct ThrowingFunctionReturnBuilder<
+    T: MockableService,
+    ParentBuilder: EffectBuilder<T>,
+    ReturnType,
+    ProduceType
+> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionVerifyBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionVerifyBuilder.swift
@@ -9,5 +9,5 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., a `VerifyBuilder`)
 /// to verify the expected number of invocations for a throwing function of a mock service.
-public typealias ThrowingFunctionVerifyBuilder<T: MockService, ParentBuilder: AssertionBuilder<T>>
+public typealias ThrowingFunctionVerifyBuilder<T: MockableService, ParentBuilder: AssertionBuilder<T>>
     = FunctionVerifyBuilder<T, ParentBuilder>

--- a/Sources/Mockable/Builder/MockableService.swift
+++ b/Sources/Mockable/Builder/MockableService.swift
@@ -1,5 +1,5 @@
 //
-//  MockService.swift
+//  MockableService.swift
 //  Mockable
 //
 //  Created by Kolos Foltanyi on 2023. 11. 13..
@@ -9,7 +9,7 @@
 ///
 /// Conforming types must provide a `Member` type representing their members
 /// as well as builders for specifying return values, actions, and verifications.
-public protocol MockService {
+public protocol MockableService {
 
     /// A type representing the members of the mocked protocol.
     associatedtype Member: Matchable, CaseIdentifiable

--- a/Sources/Mockable/Builder/PropertyBuilders/PropertyActionBuilder.swift
+++ b/Sources/Mockable/Builder/PropertyBuilders/PropertyActionBuilder.swift
@@ -9,7 +9,7 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., an `ActionBuilder`)
 /// to specify the behavior of the getter and setter of a particular property of a mock.
-public struct PropertyActionBuilder<T: MockService, ParentBuilder: EffectBuilder<T>> {
+public struct PropertyActionBuilder<T: MockableService, ParentBuilder: EffectBuilder<T>> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/PropertyBuilders/PropertyReturnBuilder.swift
+++ b/Sources/Mockable/Builder/PropertyBuilders/PropertyReturnBuilder.swift
@@ -10,7 +10,7 @@
 /// This builder is typically used within the context of a higher-level builder (e.g., a `ReturnBuilder`)
 /// to specify the desired return value or a return value producer for the getter
 /// of a particular property of a mock.
-public struct PropertyReturnBuilder<T: MockService, ParentBuilder: EffectBuilder<T>, ReturnType> {
+public struct PropertyReturnBuilder<T: MockableService, ParentBuilder: EffectBuilder<T>, ReturnType> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/PropertyBuilders/PropertyVerifyBuilder.swift
+++ b/Sources/Mockable/Builder/PropertyBuilders/PropertyVerifyBuilder.swift
@@ -9,7 +9,7 @@
 ///
 /// This builder is typically used within the context of a higher-level builder (e.g., a `VerifyBuilder`)
 /// to verify the expected number of invocations for the getter and setter of a particular property of a mock.
-public struct PropertyVerifyBuilder<T: MockService, ParentBuilder: AssertionBuilder<T>> {
+public struct PropertyVerifyBuilder<T: MockableService, ParentBuilder: AssertionBuilder<T>> {
 
     /// Convenient type for the associated service's Member.
     public typealias Member = T.Member

--- a/Sources/Mockable/Builder/VerifyBuilder.swift
+++ b/Sources/Mockable/Builder/VerifyBuilder.swift
@@ -10,7 +10,7 @@
 public protocol AssertionBuilder<Service> {
 
     /// The mock service associated with the Builder.
-    associatedtype Service: MockService
+    associatedtype Service: MockableService
 
     /// Initializes a new instance of the builder with the provided `Mocker`.
     ///

--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -12,7 +12,7 @@ import Combine
 ///
 /// The `Mocker` class keeps track of invocations, expected return values, and actions associated with
 /// specific members of a mockable service.
-public class Mocker<Service: MockService> {
+public class Mocker<Service: MockableService> {
 
     // MARK: Public Properties
 

--- a/Sources/Mockable/Utils/Utils.swift
+++ b/Sources/Mockable/Utils/Utils.swift
@@ -27,7 +27,7 @@
 ///
 /// - Parameter service: The mockable service for which return values are specified.
 /// - Returns: The service's return value builder.
-public func given<T: MockService>(_ service: T) -> T.ReturnBuilder { service.given() }
+public func given<T: MockableService>(_ service: T) -> T.ReturnBuilder { service.given() }
 
 /// Creates a proxy for building actions for members of the given service.
 ///
@@ -51,4 +51,4 @@ public func given<T: MockService>(_ service: T) -> T.ReturnBuilder { service.giv
 ///
 /// - Parameter service: The mockable service for which actions are specified.
 /// - Returns: The service's action builder.
-public func when<T: MockService>(_ service: T) -> T.ActionBuilder { service.when() }
+public func when<T: MockableService>(_ service: T) -> T.ActionBuilder { service.when() }

--- a/Sources/MockableMacro/Factory/MockFacotry.swift
+++ b/Sources/MockableMacro/Factory/MockFacotry.swift
@@ -42,7 +42,7 @@ extension MockFacotry {
                 name: requirements.syntax.name.trimmed
             ))
             InheritedTypeSyntax(type: IdentifierTypeSyntax(
-                name: NS.MockService
+                name: NS.MockableService
             ))
         }
     }

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -53,7 +53,7 @@ enum NS {
     static let assertion: TokenSyntax = "assertion"
 
     static let Mock: TokenSyntax = "Mock"
-    static let MockService: TokenSyntax = "MockService"
+    static let MockableService: TokenSyntax = "MockableService"
     static let Bool: TokenSyntax = "Bool"
     static let GenericValue: String = "GenericValue"
     static let MockableAssertion: TokenSyntax = "MockableAssertion"

--- a/Sources/MockableTest/Utils.swift
+++ b/Sources/MockableTest/Utils.swift
@@ -24,6 +24,6 @@ import XCTest
 /// ```
 /// - Parameter service: The mockable service for which invocations are verified.
 /// - Returns: The service's verification builder.
-public func verify<T: MockService>(_ service: T) -> T.VerifyBuilder {
+public func verify<T: MockableService>(_ service: T) -> T.VerifyBuilder {
     service.verify(with: XCTAssert)
 }

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -26,7 +26,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest<Item>: Test, MockService {
+            final class MockTest<Item>: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -116,7 +116,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest<Item>: Test, MockService where Item: Equatable, Item: Hashable {
+            final class MockTest<Item>: Test, MockableService where Item: Equatable, Item: Hashable {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -206,7 +206,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest<Item>: Test, MockService where Item: Equatable, Item: Hashable {
+            final class MockTest<Item>: Test, MockableService where Item: Equatable, Item: Hashable {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {

--- a/Tests/MockableMacroTests/AttributesTests.swift
+++ b/Tests/MockableMacroTests/AttributesTests.swift
@@ -50,7 +50,7 @@ final class AttributesTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockAttributeTest: AttributeTest, MockService {
+            final class MockAttributeTest: AttributeTest, MockableService {
                 private var mocker = Mocker<MockAttributeTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -24,7 +24,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -112,7 +112,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -200,7 +200,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -27,7 +27,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -136,7 +136,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -228,7 +228,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -24,7 +24,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -112,7 +112,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -204,7 +204,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -26,7 +26,7 @@ final class InitRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -103,7 +103,7 @@ final class InitRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -26,7 +26,7 @@ final class NameCollisionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -137,7 +137,7 @@ final class NameCollisionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -26,7 +26,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -141,7 +141,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
@@ -274,7 +274,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockService {
+            final class MockTest: Test, MockableService {
                 private var mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {


### PR DESCRIPTION
# Summary

This PR renames `MockService` to `MockableService` in order to fix a name collision.

# Details

This happens when we try to mock a protocol named `Service`. This is common inside a local Swift package, to expose a particular service (API, storage, etc.).
The generated macro will have a `MockService` class and will collide with the `MockService` protocol (public) inside the Mockable package.

We got the following build errors:
```
'MockService' inherits from itself
Type 'MyPackage.MockService' does not conform to protocol 'Mockable.MockService'
```

Renaming `MockService` to `MockableService` fix it.