### PR TITLE
fix: support sendable conformance

### DIFF
--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -12,7 +12,7 @@ import Combine
 ///
 /// The `Mocker` class keeps track of invocations, expected return values, and actions associated with
 /// specific members of a mockable service.
-public class Mocker<Service: MockableService> {
+public class Mocker<Service: MockableService>: @unchecked Sendable {
 
     // MARK: Public Properties
 

--- a/Sources/MockableMacro/Factory/MemberFactory.swift
+++ b/Sources/MockableMacro/Factory/MemberFactory.swift
@@ -38,7 +38,7 @@ extension MemberFactory {
     private static func mocker(_ requirements: Requirements) -> VariableDeclSyntax {
         VariableDeclSyntax(
             modifiers: [DeclModifierSyntax(name: .keyword(.private))],
-            bindingSpecifier: .keyword(.var)
+            bindingSpecifier: .keyword(.let)
         ) {
             PatternBindingSyntax(
                 pattern: IdentifierPatternSyntax(identifier: NS.mocker),

--- a/Tests/MockableMacroTests/AccessModifierTests.swift
+++ b/Tests/MockableMacroTests/AccessModifierTests.swift
@@ -29,7 +29,7 @@ final class AccessModifierTests: MockableMacroTestCase {
 
             #if MOCKING
             private final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -27,7 +27,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest<Item>: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -117,7 +117,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest<Item>: Test, MockableService where Item: Equatable, Item: Hashable {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -207,7 +207,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest<Item>: Test, MockableService where Item: Equatable, Item: Hashable {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/AttributesTests.swift
+++ b/Tests/MockableMacroTests/AttributesTests.swift
@@ -51,7 +51,7 @@ final class AttributesTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockAttributeTest: AttributeTest, MockableService {
-                private var mocker = Mocker<MockAttributeTest>()
+                private let mocker = Mocker<MockAttributeTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -25,7 +25,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -113,7 +113,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -201,7 +201,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -28,7 +28,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -137,7 +137,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -229,7 +229,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -25,7 +25,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -113,7 +113,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -205,7 +205,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -27,7 +27,7 @@ final class InitRequirementTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -104,7 +104,7 @@ final class InitRequirementTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -27,7 +27,7 @@ final class NameCollisionTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -138,7 +138,7 @@ final class NameCollisionTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -247,7 +247,7 @@ final class NameCollisionTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -27,7 +27,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -142,7 +142,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -275,7 +275,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
 
             #if MOCKING
             final class MockTest: Test, MockableService {
-                private var mocker = Mocker<MockTest>()
+                private let mocker = Mocker<MockTest>()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)

--- a/Tests/MockableTests/Protocols/TestProtocol.swift
+++ b/Tests/MockableTests/Protocols/TestProtocol.swift
@@ -8,7 +8,7 @@
 import MockableTest
 
 @Mockable
-protocol TestProtocol where Item2: Identifiable {
+protocol TestProtocol: Sendable where Item2: Identifiable {
 
     // MARK: Associated Types
 


### PR DESCRIPTION
As reported in #57, generated mock implementations will not compile with strict concurrency checking in case of `Sendable` protocols.

Changing the mocker variable to a `let` constant and adding `@unchecked Sendable` to the `Mocker` class will resolve the issue. `@unchecked Sendable` is safe to use as Mocker has its own synchronisation implemented for all mutations inside.