### PR TITLE
Add Swift 6 support

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,13 +9,9 @@ jobs:
   update_docs:
     name: Update Documentation
     runs-on: macOS-13
-
+    env:
+      MOCKABLE_DOC: true
     steps:
-    - name: Set up Swift
-      uses: swift-actions/setup-swift@v1
-      with:
-        swift-version: '5.9'
-  
     - name: Checkout main branch
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,17 +27,38 @@ jobs:
         run: commitlint -x @commitlint/config-conventional --from=${{ github.event.pull_request.base.sha }} --to=${{ github.event.pull_request.head.sha }}
 
   test:
-    name: Build Package and Run Tests
-    runs-on: macOS-13
+    name: Build and Test using Swift 5.9
+    runs-on: macos-14
+    env:
+      MOCKABLE_TEST: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Swift
-        uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: '5.9'
+      - name: Select Xcode 15.2 (Swift 5.9.2)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_15.2.app
+          swift -version
 
       - name: Run Tests
         run: |
           Scripts/test.sh
+
+  test-swift6:
+    name: Build and Test using Swift 6
+    runs-on: macos-14
+    env:
+      MOCKABLE_LINT: true
+      MOCKABLE_TEST: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 16 (Swift 6.0)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.app
+          swift --version
+
+      - name: Run Tests
+        run: |
+          Scripts/lint.sh & Scripts/test.sh

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,8 @@ disabled_rules:
   - nesting
   - switch_case_alignment
   - void_function_in_ternary
+  - type_name
+
 opt_in_rules:
   - closure_spacing
   - convenience_type
@@ -156,9 +158,6 @@ trailing_whitespace:
   severity: warning
 unused_closure_parameter:
   severity: error
-type_name:
-  excluded:
-    - NS
 identifier_name:
   excluded:
     - to

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let isDev = Context.environment["MOCKABLE_DEV"].flatMap(Bool.init) ?? false
 func ifDev<T>(add list: [T]) -> [T] { isDev ? list : [] }
 
 let devDependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.2"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", exact: "0.5.2"),
     .package(url: "https://github.com/realm/SwiftLint", exact: "0.55.1"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")
 ]
@@ -45,15 +45,15 @@ let package = Package(
         )
     ],
     dependencies: ifDev(add: devDependencies) + [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"511.0.0"),
-        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", .upToNextMajor(from: "1.4.1"))
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"601.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-issue-reporting", .upToNextMajor(from: "1.4.1"))
     ],
     targets: ifDev(add: devTargets) + [
         .target(
             name: "Mockable",
             dependencies: [
                 "MockableMacro",
-                .product(name: "IssueReporting", package: "xctest-dynamic-overlay")
+                .product(name: "IssueReporting", package: "swift-issue-reporting")
             ],
             plugins: ifDev(add: devPlugins)
         ),
@@ -65,5 +65,6 @@ let package = Package(
             ],
             plugins: ifDev(add: devPlugins)
         )
-    ]
+    ],
+    swiftLanguageVersions: [.v5, .version("6")]
 )

--- a/Scripts/doc.sh
+++ b/Scripts/doc.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-export MOCKABLE_DEV=true
 swift package \
  --allow-writing-to-directory ./docs \
  generate-documentation \

--- a/Scripts/open.sh
+++ b/Scripts/open.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-export MOCKABLE_DEV=true
+export MOCKABLE_LINT=true
+export MOCKABLE_TEST=true
 open Package.swift

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -2,6 +2,5 @@
 
 set -eo pipefail
 
-export MOCKABLE_DEV=true
 swift build
 swift test

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -2,8 +2,6 @@
 
 set -eo pipefail
 
-export MOCKABLE_DEV=false
-swift build
-
 export MOCKABLE_DEV=true
+swift build
 swift test

--- a/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
+++ b/Sources/Mockable/Builder/FunctionBuilders/ThrowingFunctionReturnBuilder.swift
@@ -13,6 +13,7 @@ public struct ThrowingFunctionReturnBuilder<
     T: MockableService,
     ParentBuilder: Builder<T>,
     ReturnType,
+    ErrorType: Error,
     ProduceType
 > {
 
@@ -50,7 +51,7 @@ public struct ThrowingFunctionReturnBuilder<
     /// - Parameter error: The error to be thrown for mocking the specified member.
     /// - Returns: The parent builder, used for chaining additional specifications.
     @discardableResult
-    public func willThrow(_ error: Error) -> ParentBuilder {
+    public func willThrow(_ error: ErrorType) -> ParentBuilder {
         mocker.addReturnValue(.throw(error), for: member)
         return .init(mocker: mocker)
     }

--- a/Sources/Mockable/Builder/MockableService.swift
+++ b/Sources/Mockable/Builder/MockableService.swift
@@ -12,7 +12,7 @@
 public protocol MockableService {
 
     /// A type representing the members of the mocked protocol.
-    associatedtype Member: Matchable, CaseIdentifiable
+    associatedtype Member: Matchable, CaseIdentifiable, Sendable
 
     /// A builder responsible for registering return values.
     associatedtype ReturnBuilder: Builder<Self>

--- a/Sources/Mockable/Extensions/Async+Timeout.swift
+++ b/Sources/Mockable/Extensions/Async+Timeout.swift
@@ -17,7 +17,7 @@ public struct TimeoutError: Error {}
 /// - Returns: Returns the result of `work` if it completed in time.
 /// - Throws: Throws ``TimedOutError`` if the timeout expires before `work` completes.
 ///   If `work` throws an error before the timeout expires, that error is propagated to the caller.
-func withTimeout<Value>(
+func withTimeout<Value: Sendable>(
     after maxDuration: TimeInterval,
     _ operation: @Sendable @escaping () async throws -> Value
 ) async throws -> Value {

--- a/Sources/Mockable/Extensions/Publisher+Async.swift
+++ b/Sources/Mockable/Extensions/Publisher+Async.swift
@@ -5,9 +5,13 @@
 //  Created by Kolos Foltanyi on 2024. 04. 07..
 //
 
+#if swift(>=6)
+@preconcurrency import Combine
+#else
 import Combine
+#endif
 
-extension Publisher where Failure == Never {
+extension Publisher where Failure == Never, Output: Sendable {
     var stream: AsyncStream<Output> {
         AsyncStream<Output> { continuation in
             let cancellable = sink {

--- a/Sources/Mockable/Matcher/Matcher.swift
+++ b/Sources/Mockable/Matcher/Matcher.swift
@@ -35,7 +35,12 @@ public class Matcher {
     // MARK: Private Properties
 
     private var matchers: [MatcherType] = []
+
+    #if swift(>=6)
+    nonisolated(unsafe) private static var `default` = Matcher()
+    #else
     private static var `default` = Matcher()
+    #endif
 
     // MARK: Init
 

--- a/Sources/Mockable/Mocker/Matchable.swift
+++ b/Sources/Mockable/Mocker/Matchable.swift
@@ -6,7 +6,7 @@
 //
 
 /// A protocol for types that can be used as matchers in mock assertions.
-public protocol Matchable {
+public protocol Matchable: Sendable {
     /// Determines if the receiver matches another instance of the same type according to custom criteria.
     ///
     /// - Parameter other: The instance to compare against.

--- a/Sources/Mockable/Mocker/Matchable.swift
+++ b/Sources/Mockable/Mocker/Matchable.swift
@@ -6,7 +6,7 @@
 //
 
 /// A protocol for types that can be used as matchers in mock assertions.
-public protocol Matchable: Sendable {
+public protocol Matchable {
     /// Determines if the receiver matches another instance of the same type according to custom criteria.
     ///
     /// - Parameter other: The instance to compare against.

--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -206,6 +206,25 @@ public class Mocker<Service: MockableService>: @unchecked Sendable {
     public func mockThrowing<V>(_ member: Member, producerResolver: (Any) throws -> V) throws -> V {
         return try mock(member, producerResolver, .none)
     }
+
+    #if swift(>=6)
+    /// Mocks a throwing member, performing associated actions and providing the expected return value.
+    ///
+    /// - Parameters:
+    ///   - member: The member to mock.
+    ///   - producerResolver: A closure resolving the produced value.
+    /// - Returns: The expected return value.
+    @discardableResult
+    public func mockThrowing<V, E>(_ member: Member,
+                                   error: E.Type,
+                                   producerResolver: (Any) throws -> V) throws(E) -> V {
+        do {
+            return try mock(member, producerResolver, .none)
+        } catch {
+            throw error as! E // swiftlint:disable:this force_cast
+        }
+    }
+    #endif
 }
 
 // MARK: - Helpers
@@ -315,6 +334,25 @@ extension Mocker {
         let relaxed = currentPolicy.contains(.relaxedThrowingVoid)
         return try mock(member, producerResolver, relaxed ? .value(()) : .none)
     }
+
+    #if swift(>=6)
+    /// Mocks a throwing member, performing associated actions and providing the expected return value.
+    ///
+    /// - Parameters:
+    ///   - member: The member to mock.
+    ///   - producerResolver: A closure resolving the produced value.
+    /// - Returns: The expected return value.
+    public func mockThrowing<E>(_ member: Member,
+                                error: E.Type,
+                                producerResolver: (Any) throws -> Void) throws(E) {
+        do {
+            let relaxed = currentPolicy.contains(.relaxedThrowingVoid)
+            return try mock(member, producerResolver, relaxed ? .value(()) : .none)
+        } catch {
+            throw error as! E // swiftlint:disable:this force_cast
+        }
+    }
+    #endif
 }
 
 // MARK: - Optional
@@ -350,6 +388,28 @@ extension Mocker {
         let relaxed = currentPolicy.contains(.relaxedOptional)
         return try mock(member, producerResolver, relaxed ? .value(nil) : .none)
     }
+
+    #if swift(>=6)
+    /// Mocks a throwing member, performing associated actions and providing the expected return value.
+    ///
+    /// - Parameters:
+    ///   - member: The member to mock.
+    ///   - producerResolver: A closure resolving the produced value.
+    /// - Returns: The expected return value.
+    @discardableResult
+    public func mockThrowing<V, E>(
+        _ member: Member,
+        error: E.Type,
+        producerResolver: (Any) throws -> V
+    ) throws(E) -> V where V: ExpressibleByNilLiteral {
+        do {
+            let relaxed = currentPolicy.contains(.relaxedThrowingVoid)
+            return try mock(member, producerResolver, relaxed ? .value(nil) : .none)
+        } catch {
+            throw error as! E // swiftlint:disable:this force_cast
+        }
+    }
+    #endif
 }
 
 // MARK: - Mockable
@@ -385,6 +445,28 @@ extension Mocker {
         let relaxed = currentPolicy.contains(.relaxedMocked)
         return try mock(member, producerResolver, relaxed ? .value(.mock) : .none)
     }
+
+    #if swift(>=6)
+    /// Mocks a throwing member, performing associated actions and providing the expected return value.
+    ///
+    /// - Parameters:
+    ///   - member: The member to mock.
+    ///   - producerResolver: A closure resolving the produced value.
+    /// - Returns: The expected return value.
+    @discardableResult
+    public func mockThrowing<V, E>(
+        _ member: Member,
+        error: E,
+        producerResolver: (Any) throws -> V
+    ) throws(E) -> V where V: Mocked {
+        do {
+            let relaxed = currentPolicy.contains(.relaxedMocked)
+            return try mock(member, producerResolver, relaxed ? .value(.mock) : .none)
+        } catch {
+            throw error as! E // swiftlint:disable:this force_cast
+        }
+    }
+    #endif
 }
 
 // MARK: - Mockable + Optional
@@ -431,4 +513,31 @@ extension Mocker {
             return try mock(member, producerResolver, .none)
         }
     }
+
+    #if swift(>=6)
+    /// Mocks a throwing member, performing associated actions and providing the expected return value.
+    ///
+    /// - Parameters:
+    ///   - member: The member to mock.
+    ///   - producerResolver: A closure resolving the produced value.
+    /// - Returns: The expected return value.
+    @discardableResult
+    public func mockThrowing<V, E>(
+        _ member: Member,
+        error: E.Type,
+        producerResolver: (Any) throws -> V
+    ) throws(E) -> V where V: Mocked, V: ExpressibleByNilLiteral {
+        do {
+            if currentPolicy.contains(.relaxedMocked) {
+                return try mock(member, producerResolver, .value(.mock))
+            } else if currentPolicy.contains(.relaxedOptional) {
+                return try mock(member, producerResolver, .value(nil))
+            } else {
+                return try mock(member, producerResolver, .none)
+            }
+        } catch {
+            throw error as! E // swiftlint:disable:this force_cast
+        }
+    }
+    #endif
 }

--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -166,11 +166,11 @@ public class Mocker<Service: MockableService>: @unchecked Sendable {
             guard scopes.contains(scope) else { return }
             switch scope {
             case .given:
-                returns.removeAll()
+                returns = [:]
             case .when:
-                actions.removeAll()
+                actions = [:]
             case .verify:
-                invocations.removeAll()
+                invocations = []
             }
         }
     }

--- a/Sources/Mockable/Mocker/MockerPolicy.swift
+++ b/Sources/Mockable/Mocker/MockerPolicy.swift
@@ -9,11 +9,15 @@
 ///
 /// MockerPolicy can be used to customize mocking behavior and disable the requirement of
 /// return value registration in case of certain types.
-public struct MockerPolicy: OptionSet {
+public struct MockerPolicy: OptionSet, Sendable {
     /// Default policy to use when none was explicitly specified for a mock.
     ///
     /// Change this property to set the default policy to use for all mocks. Defaults to `strict`.
+    #if swift(>=6)
+    nonisolated(unsafe) public static var `default`: Self = .strict
+    #else
     public static var `default`: Self = .strict
+    #endif
 
     /// All return values must be registered, a fatal error will occur otherwise.
     public static let strict: Self = []

--- a/Sources/Mockable/Models/Count.swift
+++ b/Sources/Mockable/Models/Count.swift
@@ -14,7 +14,7 @@
 ///     .fetch(for: .any)
 ///     .called(.from(1, to: 5))
 /// ```
-public enum Count: ExpressibleByIntegerLiteral {
+public enum Count: ExpressibleByIntegerLiteral, Sendable {
     /// The associated type for the integer literal.
     public typealias IntegerLiteralType = Int
 

--- a/Sources/Mockable/Models/Parameter.swift
+++ b/Sources/Mockable/Models/Parameter.swift
@@ -6,7 +6,7 @@
 //
 
 /// An enumeration representing different types of parameters used in mocking.
-public enum Parameter<Value> {
+public enum Parameter<Value>: @unchecked Sendable {
     /// Matches any value.
     case any
     /// Matches a specific value.

--- a/Sources/MockableMacro/Extensions/FunctionParameterSyntax+Extensions.swift
+++ b/Sources/MockableMacro/Extensions/FunctionParameterSyntax+Extensions.swift
@@ -31,6 +31,13 @@ extension FunctionParameterSyntax {
     }
 
     var isInout: Bool {
+        #if canImport(SwiftSyntax600)
+        type.as(AttributedTypeSyntax.self)?.specifiers.contains { specifier in
+            guard case .simpleTypeSpecifier(let simpleSpecifier) = specifier else { return false }
+            return simpleSpecifier.specifier.tokenKind == .keyword(.inout)
+        } ?? false
+        #else
         type.as(AttributedTypeSyntax.self)?.specifier?.tokenKind == .keyword(.inout)
+        #endif
     }
 }

--- a/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
@@ -81,6 +81,9 @@ extension FunctionRequirement {
             if let returnType = functionReturnType(for: kind) {
                 returnType
             }
+            if let errorType = errorType(for: kind) {
+                errorType
+            }
             if let produceType = functionProduceType(for: kind) {
                 produceType
             }
@@ -92,6 +95,18 @@ extension FunctionRequirement {
                 genericArgumentClause: .init(arguments: arguments)
             )
         )
+    }
+
+    private func errorType(for kind: BuilderKind) -> GenericArgumentSyntax? {
+        guard syntax.isThrowing && kind == .return else { return nil }
+        #if canImport(SwiftSyntax600)
+        guard let errorType = syntax.errorType else {
+            return GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: NS.Error))
+        }
+        return GenericArgumentSyntax(argument: errorType.trimmed)
+        #else
+        return GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: NS.Error))
+        #endif
     }
 
     private func functionReturnType(for kind: BuilderKind) -> GenericArgumentSyntax? {

--- a/Sources/MockableMacro/Factory/Buildable/Variable+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Variable+Buildable.swift
@@ -104,6 +104,9 @@ extension VariableRequirement {
             if let returnType = try variableReturnType(for: kind) {
                 returnType
             }
+            if let errorType = try errorType(for: kind) {
+                errorType
+            }
             if let produceType = try variableProduceType(for: kind) {
                 produceType
             }
@@ -114,6 +117,18 @@ extension VariableRequirement {
             name: name,
             genericArgumentClause: .init(arguments: arguments)
         )
+    }
+
+    private func errorType(for kind: BuilderKind) throws -> GenericArgumentSyntax? {
+        guard try syntax.isThrowing && syntax.isComputed && kind == .return else { return nil }
+        #if canImport(SwiftSyntax600)
+        guard let errorType = try syntax.errorType else {
+            return GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: NS.Error))
+        }
+        return GenericArgumentSyntax(argument: errorType.trimmed)
+        #else
+        return GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: NS.Error))
+        #endif
     }
 
     private func variableReturnType(for kind: BuilderKind) throws -> GenericArgumentSyntax? {

--- a/Sources/MockableMacro/Factory/EnumFactory.swift
+++ b/Sources/MockableMacro/Factory/EnumFactory.swift
@@ -39,6 +39,9 @@ extension EnumFactory {
                     name: NS.CaseIdentifiable
                 )
             )
+            InheritedTypeSyntax(
+                type: IdentifierTypeSyntax(name: NS.Sendable)
+            )
         }
     }
 

--- a/Sources/MockableMacro/Factory/MemberFactory.swift
+++ b/Sources/MockableMacro/Factory/MemberFactory.swift
@@ -30,7 +30,7 @@ enum MemberFactory: Factory {
 extension MemberFactory {
     private static func defaultInit(_ requirements: Requirements) -> InitializerDeclSyntax {
         InitializerDeclSyntax(
-            modifiers: requirements.modifiers,
+            modifiers: requirements.isActor ? requirements.modifiers : memberModifiers(requirements),
             signature: .init(parameterClause: defaultInitParameters),
             body: .init { CodeBlockItemSyntax(item: .expr(mockerAssignmentWithPolicy)) }
         )
@@ -81,7 +81,7 @@ extension MemberFactory {
     ) -> VariableDeclSyntax {
         VariableDeclSyntax(
             attributes: unavailableAttribute(message: message),
-            modifiers: clauseModifiers(requirements),
+            modifiers: memberModifiers(requirements),
             bindingSpecifier: .keyword(.var),
             bindings: PatternBindingListSyntax {
                 PatternBindingSyntax(
@@ -114,7 +114,7 @@ extension MemberFactory {
 
     private static func reset(_ requirements: Requirements) -> FunctionDeclSyntax {
         FunctionDeclSyntax(
-            modifiers: requirements.modifiers,
+            modifiers: memberModifiers(requirements),
             name: NS.reset,
             signature: .init(
                 parameterClause: FunctionParameterClauseSyntax(
@@ -125,11 +125,9 @@ extension MemberFactory {
         )
     }
 
-    private static func clauseModifiers(_ requirements: Requirements) -> DeclModifierListSyntax {
+    private static func memberModifiers(_ requirements: Requirements) -> DeclModifierListSyntax {
         var modifiers = requirements.modifiers
-        if requirements.isActor {
-            modifiers.append(DeclModifierSyntax(name: .keyword(.nonisolated)))
-        }
+        modifiers.append(DeclModifierSyntax(name: .keyword(.nonisolated)))
         return modifiers
     }
 

--- a/Sources/MockableMacro/Factory/MockFactory.swift
+++ b/Sources/MockableMacro/Factory/MockFactory.swift
@@ -5,7 +5,11 @@
 //  Created by Kolos Foltanyi on 2024. 03. 28..
 //
 
+#if canImport(SwiftSyntax600) || swift(<6)
 import SwiftSyntax
+#else
+@preconcurrency import SwiftSyntax
+#endif
 
 /// Factory to generate the mock service declaration.
 ///

--- a/Sources/MockableMacro/Factory/Mockable/Function+Mockable.swift
+++ b/Sources/MockableMacro/Factory/Mockable/Function+Mockable.swift
@@ -87,6 +87,9 @@ extension FunctionRequirement {
                 LabeledExprSyntax(
                     expression: DeclReferenceExprSyntax(baseName: NS.member)
                 )
+                if let errorTypeExpression {
+                    errorTypeExpression
+                }
             },
             rightParen: .rightParenToken(),
             trailingClosure: mockerClosure
@@ -96,6 +99,22 @@ extension FunctionRequirement {
         } else {
             ExprSyntax(call)
         }
+    }
+
+    private var errorTypeExpression: LabeledExprSyntax? {
+        #if canImport(SwiftSyntax600)
+        guard let type = syntax.errorType else { return nil }
+        return LabeledExprSyntax(
+            label: NS.error,
+            colon: .colonToken(),
+            expression: MemberAccessExprSyntax(
+                base: DeclReferenceExprSyntax(baseName: .identifier(type.trimmedDescription)),
+                declName: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
+            )
+        )
+        #else
+        return nil
+        #endif
     }
 
     private var mockerClosure: ClosureExprSyntax {

--- a/Sources/MockableMacro/Factory/Mockable/Variable+Mockable.swift
+++ b/Sources/MockableMacro/Factory/Mockable/Variable+Mockable.swift
@@ -87,10 +87,13 @@ extension VariableRequirement {
                     )
                 ),
                 leftParen: .leftParenToken(),
-                arguments: LabeledExprListSyntax {
+                arguments: try LabeledExprListSyntax {
                     LabeledExprSyntax(
                         expression: DeclReferenceExprSyntax(baseName: NS.member)
                     )
+                    if let errorTypeExpression = try errorTypeExpression {
+                        errorTypeExpression
+                    }
                 },
                 rightParen: .rightParenToken(),
                 trailingClosure: try mockerClosure
@@ -100,6 +103,24 @@ extension VariableRequirement {
             } else {
                 ExprSyntax(call)
             }
+        }
+    }
+
+    private var errorTypeExpression: LabeledExprSyntax? {
+        get throws {
+            #if canImport(SwiftSyntax600)
+            guard let type = try syntax.errorType else { return nil }
+            return LabeledExprSyntax(
+                label: NS.error,
+                colon: .colonToken(),
+                expression: MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: .identifier(type.trimmedDescription)),
+                    declName: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
+                )
+            )
+            #else
+            return nil
+            #endif
         }
     }
 

--- a/Sources/MockableMacro/MockableMacro.swift
+++ b/Sources/MockableMacro/MockableMacro.swift
@@ -7,16 +7,21 @@
 
 import SwiftSyntax
 import SwiftSyntaxMacros
+import SwiftDiagnostics
 
 public enum MockableMacro: PeerMacro {
     public static func expansion(
-        of _: AttributeSyntax,
+        of node: AttributeSyntax,
         providingPeersOf declaration: some DeclSyntaxProtocol,
-        in _: some MacroExpansionContext
+        in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
         guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
             throw MockableMacroError.notAProtocol
         }
+
+        #if swift(>=6) && !canImport(SwiftSyntax600)
+        context.diagnose(Diagnostic(node: node, message: MockableMacroWarning.versionMismatch))
+        #endif
 
         let requirements = try Requirements(protocolDecl)
         let declaration = try MockFactory.build(from: requirements)

--- a/Sources/MockableMacro/MockableMacroWarning.swift
+++ b/Sources/MockableMacro/MockableMacroWarning.swift
@@ -1,0 +1,48 @@
+//
+//  MockableMacroWarning.swift
+//  Mockable
+//
+//  Created by Kolos Foltanyi on 2024. 12. 01..
+//
+
+import SwiftSyntax
+import SwiftDiagnostics
+
+public enum MockableMacroWarning {
+    case versionMismatch
+}
+
+// MARK: - DiagnosticMessage
+
+extension MockableMacroWarning: DiagnosticMessage {
+    public var message: String {
+        switch self {
+        case .versionMismatch: """
+        Your SwiftSyntax version is pinned to \(swiftSyntaxVersion).x.x by some of your dependencies. \
+        Using a lower SwiftSyntax version than your Swift version may lead to issues when using Mockable.
+        """
+        }
+    }
+    public var diagnosticID: MessageID {
+        switch self {
+        case .versionMismatch: MessageID(domain: "Mockable", id: "MockableMacroWarning.versionMismatch")
+        }
+    }
+    public var severity: DiagnosticSeverity { .warning }
+}
+
+// MARK: - Helpers
+
+extension MockableMacroWarning {
+    private var swiftSyntaxVersion: String {
+        #if canImport(SwiftSyntax600)
+        ">600"
+        #elseif canImport(SwiftSyntax510)
+        "510"
+        #elseif canImport(SwiftSyntax509)
+        "509"
+        #else
+        "<unknown>"
+        #endif
+    }
+}

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -41,6 +41,7 @@ enum NS {
     static let addInvocation: TokenSyntax = "addInvocation"
     static let performActions: TokenSyntax = "performActions"
     static let policy: TokenSyntax = "policy"
+    static let error: TokenSyntax = "error"
     static let iOS: TokenSyntax = "iOS"
     static let macOS: TokenSyntax = "macOS"
     static let tvOS: TokenSyntax = "tvOS"
@@ -73,6 +74,7 @@ enum NS {
     static let Set: TokenSyntax = "Set"
     static let Void: TokenSyntax = "Void"
     static let Actor: TokenSyntax = "Actor"
+    static let Error: TokenSyntax = "Error"
     static let NSObjectProtocol: String = "NSObjectProtocol"
     static let NSObject: TokenSyntax = "NSObject"
 

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -81,6 +81,7 @@ enum NS {
     static let Error: TokenSyntax = "Error"
     static let NSObjectProtocol: String = "NSObjectProtocol"
     static let NSObject: TokenSyntax = "NSObject"
+    static let Sendable: TokenSyntax = "Sendable"
 
     static func Parameter(_ type: String) -> TokenSyntax { "Parameter<\(raw: type)>" }
     static func Param(suffix: String) -> TokenSyntax { "Param\(raw: suffix)" }

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -5,7 +5,11 @@
 //  Created by Kolos Foltanyi on 2024. 03. 28..
 //
 
+#if canImport(SwiftSyntax600) || swift(<6)
 import SwiftSyntax
+#else
+@preconcurrency import SwiftSyntax
+#endif
 
 // swiftlint:disable identifier_name
 enum NS {

--- a/Tests/MockableMacroTests/AccessModifierTests.swift
+++ b/Tests/MockableMacroTests/AccessModifierTests.swift
@@ -34,21 +34,21 @@ final class AccessModifierTests: MockableMacroTestCase {
                 public typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                public var given: ReturnBuilder {
+                public nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                public var when: ActionBuilder {
+                public nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                public var verify: VerifyBuilder {
+                public nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                public func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                public nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                public init(policy: Mockable.MockerPolicy? = nil) {
+                public nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -71,7 +71,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
                     public func match(_ other: Member) -> Bool {
@@ -148,21 +148,21 @@ final class AccessModifierTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -183,7 +183,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
                     func match(_ other: Member) -> Bool {
@@ -258,21 +258,21 @@ final class AccessModifierTests: MockableMacroTestCase {
                 public typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                public var given: ReturnBuilder {
+                public nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                public var when: ActionBuilder {
+                public nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                public var verify: VerifyBuilder {
+                public nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                public func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                public nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                public init(policy: Mockable.MockerPolicy? = nil) {
+                public nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -284,7 +284,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo
                     public func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/ActorConformanceTests.swift
+++ b/Tests/MockableMacroTests/ActorConformanceTests.swift
@@ -47,7 +47,7 @@ final class ActorConformanceTests: MockableMacroTestCase {
                 nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
                 init(policy: Mockable.MockerPolicy? = nil) {
@@ -87,7 +87,7 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo
                     case m2_quz
                     case m3_bar(number: Parameter<Int>)

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -30,21 +30,21 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -56,7 +56,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -119,21 +119,21 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -145,7 +145,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -208,21 +208,21 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -234,7 +234,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/AttributesTests.swift
+++ b/Tests/MockableMacroTests/AttributesTests.swift
@@ -54,21 +54,21 @@ final class AttributesTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockAttributeTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -115,7 +115,7 @@ final class AttributesTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_prop
                     case m2_prop2
                     case m3_test

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -28,21 +28,21 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -54,7 +54,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(&value)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_modifyValue(Parameter<Int>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -115,21 +115,21 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -141,7 +141,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(values)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_printValues(Parameter<[Int]>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -202,21 +202,21 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -228,7 +228,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -30,21 +30,21 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -63,7 +63,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_returnsAndThrows
                     case m2_canThrowError
                     func match(_ other: Member) -> Bool {
@@ -138,21 +138,21 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -164,7 +164,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -229,21 +229,21 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -269,7 +269,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer(param)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_asyncFunction
                     case m2_asyncThrowingFunction
                     case m3_asyncParamFunction(param: Parameter<() async throws -> Void>)

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -5,7 +5,6 @@
 //  Created by Kolos Foltanyi on 2023. 11. 21..
 //
 
-
 import MacroTesting
 import XCTest
 
@@ -83,10 +82,10 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func returnsAndThrows() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, () throws -> String> {
+                    func returnsAndThrows() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, Error, () throws -> String> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    func canThrowError() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, () throws -> Void> {
+                    func canThrowError() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, Error, () throws -> Void> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
@@ -295,10 +294,10 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     func asyncFunction() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, () throws -> Void> {
+                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, Error, () throws -> Void> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () async throws -> Void) throws -> Void> {
+                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, Error, (@escaping () async throws -> Void) throws -> Void> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -28,21 +28,21 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -54,7 +54,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo(item: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -115,21 +115,21 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -141,7 +141,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_genericFunc(item: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -206,21 +206,21 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -235,7 +235,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(p1, p2, p3, p4)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_method1(p1: Parameter<GenericValue>, p2: Parameter<GenericValue>, p3: Parameter<GenericValue>, p4: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -303,21 +303,21 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -331,7 +331,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_prop
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -393,21 +393,21 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -421,7 +421,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_prop
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -483,21 +483,21 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -509,7 +509,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -571,21 +571,21 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -597,7 +597,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/InheritedTypeMappingTests.swift
+++ b/Tests/MockableMacroTests/InheritedTypeMappingTests.swift
@@ -28,21 +28,21 @@ final class InheritedTypeMappingTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTestObject>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -54,7 +54,7 @@ final class InheritedTypeMappingTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -30,21 +30,21 @@ final class InitRequirementTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -53,7 +53,7 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name: String) {
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }
@@ -106,21 +106,21 @@ final class InitRequirementTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -131,7 +131,7 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name value: String, _ index: Int) {
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -30,21 +30,21 @@ final class NameCollisionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -63,7 +63,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_fetchData(for: Parameter<Int>)
                     case m2_fetchData(for: Parameter<String>)
                     func match(_ other: Member) -> Bool {
@@ -140,21 +140,21 @@ final class NameCollisionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -173,7 +173,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_fetchData(forA: Parameter<String>)
                     case m2_fetchData(forB: Parameter<String>)
                     func match(_ other: Member) -> Bool {
@@ -248,21 +248,21 @@ final class NameCollisionTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -274,7 +274,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(param)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_repeat(param: Parameter<Bool>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -344,13 +344,13 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var throwingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Int, () throws -> Int> {
+                    var throwingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Int, Error, () throws -> Int> {
                         .init(mocker, kind: .m1_throwingProperty)
                     }
                     var asyncProperty: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
                         .init(mocker, kind: .m2_asyncProperty)
                     }
-                    var asyncThrowingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, () throws -> String> {
+                    var asyncThrowingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, Error, () throws -> String> {
                         .init(mocker, kind: .m3_asyncThrowingProperty)
                     }
                 }

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -30,21 +30,21 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -67,7 +67,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_computedInt
                     case m2_computedString
                     func match(_ other: Member) -> Bool {
@@ -144,21 +144,21 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -191,7 +191,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         mocker.performActions(for: member)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_get_mutableInt
                     case m1_set_mutableInt(newValue: Parameter<Int>)
                     case m2_get_mutableString
@@ -276,21 +276,21 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTest>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -322,7 +322,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_throwingProperty
                     case m2_asyncProperty
                     case m3_asyncThrowingProperty

--- a/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
+++ b/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
@@ -33,21 +33,21 @@ final class TypedThrowsTests_Swift6: MockableMacroTestCase {
                 typealias Mocker = Mockable.Mocker<MockTypedErrorProtocol>
                 private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) instead. ")
-                var given: ReturnBuilder {
+                nonisolated var given: ReturnBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use when(_ service:) instead. ")
-                var when: ActionBuilder {
+                nonisolated var when: ActionBuilder {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) instead. ")
-                var verify: VerifyBuilder {
+                nonisolated var verify: VerifyBuilder {
                     .init(mocker: mocker)
                 }
-                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: Mockable.MockerPolicy? = nil) {
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -68,7 +68,7 @@ final class TypedThrowsTests_Swift6: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
                     case m1_baz
                     case m2_foo
                     func match(_ other: Member) -> Bool {

--- a/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
+++ b/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
@@ -1,0 +1,127 @@
+//
+//  TypedThrowsTests.swift
+//  
+//
+//  Created by Kolos Foltanyi on 08/07/2024.
+//
+
+import MacroTesting
+import XCTest
+import SwiftSyntax
+@testable import Mockable
+
+#if canImport(SwiftSyntax600)
+final class TypedThrowsTests_Swift6: MockableMacroTestCase {
+    func test_typed_throws_requirement() {
+        assertMacro {
+          """
+          @Mockable
+          protocol TypedErrorProtocol {
+              func foo() throws(ExampleError)
+              var baz: String { get throws(ExampleError) }
+          }
+          """
+        } expansion: {
+            """
+            protocol TypedErrorProtocol {
+                func foo() throws(ExampleError)
+                var baz: String { get throws(ExampleError) }
+            }
+
+            #if MOCKING
+            final class MockTypedErrorProtocol: TypedErrorProtocol, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTypedErrorProtocol>
+                private let mocker = Mocker()
+                @available(*, deprecated, message: "Use given(_ service:) instead. ")
+                var given: ReturnBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use when(_ service:) instead. ")
+                var when: ActionBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use verify(_ service:) instead. ")
+                var verify: VerifyBuilder {
+                    .init(mocker: mocker)
+                }
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                    mocker.reset(scopes: scopes)
+                }
+                init(policy: Mockable.MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
+                }
+                func foo() throws(ExampleError) {
+                    let member: Member = .m2_foo
+                    try mocker.mockThrowing(member, error: ExampleError.self) { producer in
+                        let producer = try cast(producer) as () throws -> Void
+                        return try producer()
+                    }
+                }
+                var baz: String {
+                    get throws(ExampleError) {
+                        let member: Member = .m1_baz
+                        return try mocker.mockThrowing(member, error: ExampleError.self) { producer in
+                            let producer = try cast(producer) as () throws -> String
+                            return try producer()
+                        }
+                    }
+                }
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
+                    case m1_baz
+                    case m2_foo
+                    func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_baz, .m1_baz):
+                            return true
+                        case (.m2_foo, .m2_foo):
+                            return true
+                        default:
+                            return false
+                        }
+                    }
+                }
+                struct ReturnBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    var baz: Mockable.ThrowingFunctionReturnBuilder<MockTypedErrorProtocol, ReturnBuilder, String, ExampleError, () throws -> String> {
+                        .init(mocker, kind: .m1_baz)
+                    }
+                    func foo() -> Mockable.ThrowingFunctionReturnBuilder<MockTypedErrorProtocol, ReturnBuilder, Void, ExampleError, () throws -> Void> {
+                        .init(mocker, kind: .m2_foo)
+                    }
+                }
+                struct ActionBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    var baz: Mockable.ThrowingFunctionActionBuilder<MockTypedErrorProtocol, ActionBuilder> {
+                        .init(mocker, kind: .m1_baz)
+                    }
+                    func foo() -> Mockable.ThrowingFunctionActionBuilder<MockTypedErrorProtocol, ActionBuilder> {
+                        .init(mocker, kind: .m2_foo)
+                    }
+                }
+                struct VerifyBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    var baz: Mockable.ThrowingFunctionVerifyBuilder<MockTypedErrorProtocol, VerifyBuilder> {
+                        .init(mocker, kind: .m1_baz)
+                    }
+                    func foo() -> Mockable.ThrowingFunctionVerifyBuilder<MockTypedErrorProtocol, VerifyBuilder> {
+                        .init(mocker, kind: .m2_foo)
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+}
+#endif

--- a/Tests/MockableTests/GivenTests_Swift6.swift
+++ b/Tests/MockableTests/GivenTests_Swift6.swift
@@ -1,0 +1,44 @@
+//
+//  GivenTests_Swift6.swift
+//  Mockable
+//
+//  Created by Kolos Foltanyi on 28/09/2024.
+//
+
+import XCTest
+import Mockable
+
+#if swift(>=6)
+final class GivenTests_Swift6: XCTestCase {
+
+    // MARK: Properties
+
+    private var mock = MockTestService_Swift6()
+
+    // MARK: Overrides
+
+    override func tearDown() {
+        mock.reset()
+        Matcher.reset()
+    }
+
+    // MARK: Tests
+
+    func test_givenTypedThrows_whenErrorSet_correctTypeThrown() {
+        given(mock)
+            .fetch().willThrow(.notFound)
+            .fetched.willThrow(.notFound)
+
+        do {
+            try mock.fetch()
+        } catch {
+            XCTAssertEqual(error, UserError.notFound)
+        }
+        do {
+            _ = try mock.fetched
+        } catch {
+            XCTAssertEqual(error, UserError.notFound)
+        }
+    }
+}
+#endif

--- a/Tests/MockableTests/Protocols/TestProtocol.swift
+++ b/Tests/MockableTests/Protocols/TestProtocol.swift
@@ -72,12 +72,12 @@ protocol TestProtocol: Actor, Sendable where Item2: Identifiable {
 
     // MARK: Attributes
 
-    @available(iOS 15, *)
+    @available(iOS 16, *)
     init(attributed: String)
 
-    @available(iOS 15, *)
+    @available(iOS 16, *)
     var attributedProp: Int { get }
 
-    @available(iOS 15, *)
+    @available(iOS 16, *)
     func attributedTest()
 }

--- a/Tests/MockableTests/Protocols/TestService_Swift6.swift
+++ b/Tests/MockableTests/Protocols/TestService_Swift6.swift
@@ -1,0 +1,18 @@
+//
+//  TestService6.swift
+//  Mockable
+//
+//  Created by Kolos Foltanyi on 28/09/2024.
+//
+
+import Mockable
+
+#if swift(>=6)
+@Mockable
+protocol TestService_Swift6 {
+    // MARK: Typed Throws
+
+    func fetch() throws(UserError)
+    var fetched: User { get throws(UserError) }
+}
+#endif

--- a/Tests/MockableTests/VerifyTests.swift
+++ b/Tests/MockableTests/VerifyTests.swift
@@ -40,12 +40,13 @@ final class VerifyTests: XCTestCase {
             .getUser(for: .any).called(.exactly(1))
     }
 
+    @MainActor
     func test_givenMockFunctionIsCalledAsyncrhonously_whenCountVerified_assertsMatchingCounts() async {
         given(mock).getUser(for: .any).willReturn(.test1)
 
         Task {
             try await Task.sleep(seconds: 0.5)
-            _ = try self.mock.getUser(for: UUID())
+            _ = try mock.getUser(for: UUID())
         }
 
         verify(mock).getUser(for: .any).called(.never)
@@ -75,6 +76,7 @@ final class VerifyTests: XCTestCase {
             .name().setCalled(.once)
     }
 
+    @MainActor
     func test_givenMockPropertyAccessedAsynchronously_whenCountVerified_assertsGetterAndSetter() async {
         let testName = "Name"
 


### PR DESCRIPTION
This PR adds support for Swift 6 and implements mocking typed throwing requirements.

- [x] Swift 6, SwiftSyntax 600 support
- [x] Typed throws support
- [x] Add Swift 6 CI jobs
- [x] Only run SwiftLint with correct Swift version (SwiftLint plugin pins SwiftSyntax version)
- [x] Add macro warning for SwiftSyntax and Swift version mismatch