### PR TITLE
fix: keep escaping closure attribute in mocks

### DIFF
--- a/Sources/MockableMacro/Extensions/FunctionDeclSyntax+Extensions.swift
+++ b/Sources/MockableMacro/Extensions/FunctionDeclSyntax+Extensions.swift
@@ -18,7 +18,7 @@ extension FunctionDeclSyntax {
 
     var closureType: FunctionTypeSyntax {
         let params = signature.parameterClause.parameters
-            .map(\.resolvedType)
+            .map { $0.resolvedType(for: .parameter) }
 
         return FunctionTypeSyntax(
             parameters: TupleTypeElementListSyntax {

--- a/Sources/MockableMacro/Extensions/FunctionParameterSyntax+Extensions.swift
+++ b/Sources/MockableMacro/Extensions/FunctionParameterSyntax+Extensions.swift
@@ -6,19 +6,31 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxMacros
+
+enum FunctionParameterTypeResolveRole {
+    /// Resolves a type that can be used for property type bindings, removes attributes.
+    case binding
+    /// Resolves a type that can be used as a function or closure parameter, keeps attributes.
+    case parameter
+}
 
 extension FunctionParameterSyntax {
-    var resolvedType: TypeSyntax {
-        let type = if let type = type.as(AttributedTypeSyntax.self) {
-            type.baseType
-        } else {
-            type
-        }
-
+    func resolvedType(for role: FunctionParameterTypeResolveRole = .binding) -> TypeSyntax {
         guard ellipsis == nil else {
             return TypeSyntax(ArrayTypeSyntax(element: type))
         }
 
-        return TypeSyntax(type)
+        guard role != .parameter else { return type }
+
+        if let attributeType = type.as(AttributedTypeSyntax.self) {
+            return TypeSyntax(attributeType.baseType)
+        } else {
+            return TypeSyntax(type)
+        }
+    }
+
+    var isInout: Bool {
+        type.as(AttributedTypeSyntax.self)?.specifier?.tokenKind == .keyword(.inout)
     }
 }

--- a/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
@@ -63,7 +63,7 @@ extension FunctionRequirement {
                 FunctionParameterSyntax(
                     firstName: parameter.firstName,
                     secondName: parameter.secondName,
-                    type: IdentifierTypeSyntax(name: NS.Parameter(parameter.resolvedType.description))
+                    type: IdentifierTypeSyntax(name: NS.Parameter(parameter.resolvedType().description))
                 )
             }
         }

--- a/Sources/MockableMacro/Factory/Caseable/Function+Caseable.swift
+++ b/Sources/MockableMacro/Factory/Caseable/Function+Caseable.swift
@@ -91,7 +91,7 @@ extension FunctionRequirement {
     }
 
     private func wrappedType(for parameter: FunctionParameterSyntax) -> IdentifierTypeSyntax {
-        let type = parameter.resolvedType.description
+        let type = parameter.resolvedType().description
         let isGeneric = syntax.containsGenericType(in: parameter)
         let identifier = isGeneric ? NS.GenericValue : type
         return IdentifierTypeSyntax(name: NS.Parameter(identifier))

--- a/Sources/MockableMacro/Factory/Mockable/Function+Mockable.swift
+++ b/Sources/MockableMacro/Factory/Mockable/Function+Mockable.swift
@@ -146,11 +146,14 @@ extension FunctionRequirement {
             leftParen: .leftParenToken(),
             arguments: LabeledExprListSyntax {
                 for parameter in syntax.signature.parameterClause.parameters {
-                    LabeledExprSyntax(
-                        expression: DeclReferenceExprSyntax(
-                            baseName: parameter.secondName?.trimmed ?? parameter.firstName.trimmed
-                        )
+                    let parameterReference = DeclReferenceExprSyntax(
+                        baseName: parameter.secondName?.trimmed ?? parameter.firstName.trimmed
                     )
+                    if parameter.isInout {
+                        LabeledExprSyntax(expression: InOutExprSyntax(expression: parameterReference))
+                    } else {
+                        LabeledExprSyntax(expression: parameterReference)
+                    }
                 }
             },
             rightParen: .rightParenToken()

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -49,8 +49,8 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 func modifyValue(_ value: inout Int) {
                     let member: Member = .m1_modifyValue(.value(value))
                     mocker.mock(member) { producer in
-                        let producer = try cast(producer) as (Int) -> Void
-                        return producer(value)
+                        let producer = try cast(producer) as (inout Int) -> Void
+                        return producer(&value)
                     }
                 }
                 enum Member: Matchable, CaseIdentifiable {
@@ -67,7 +67,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (Int) -> Void> {
+                    func modifyValue(_ value: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (inout Int) -> Void> {
                         .init(mocker, kind: .m1_modifyValue(value))
                     }
                 }
@@ -225,7 +225,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                 func execute(operation: @escaping () throws -> Void) {
                     let member: Member = .m1_execute(operation: .value(operation))
                     mocker.mock(member) { producer in
-                        let producer = try cast(producer) as (() throws -> Void) -> Void
+                        let producer = try cast(producer) as (@escaping () throws -> Void) -> Void
                         return producer(operation)
                     }
                 }
@@ -243,7 +243,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (() throws -> Void) -> Void> {
+                    func execute(operation: Parameter<() throws -> Void>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -161,7 +161,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 func execute(operation: @escaping () throws -> Void) rethrows {
                     let member: Member = .m1_execute(operation: .value(operation))
                     mocker.mock(member) { producer in
-                        let producer = try cast(producer) as (() throws -> Void) -> Void
+                        let producer = try cast(producer) as (@escaping () throws -> Void) -> Void
                         return producer(operation)
                     }
                 }
@@ -179,7 +179,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     init(mocker: Mocker<MockTest>) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (() throws -> Void) -> Void> {
+                    func execute(operation: Parameter<() throws -> Void>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
@@ -267,7 +267,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                 func asyncParamFunction(param: @escaping () async throws -> Void) async throws {
                     let member: Member = .m3_asyncParamFunction(param: .value(param))
                     try mocker.mockThrowing(member) { producer in
-                        let producer = try cast(producer) as (() async throws -> Void) throws -> Void
+                        let producer = try cast(producer) as (@escaping () async throws -> Void) throws -> Void
                         return try producer(param)
                     }
                 }
@@ -299,7 +299,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     func asyncThrowingFunction() -> ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, () throws -> Void> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, (() async throws -> Void) throws -> Void> {
+                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () async throws -> Void) throws -> Void> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }

--- a/Tests/MockableTests/GivenTests.swift
+++ b/Tests/MockableTests/GivenTests.swift
@@ -250,4 +250,30 @@ final class GivenTests: XCTestCase {
 
         XCTAssertEqual(result, 1234)
     }
+
+    func test_givenEscapingClosureParam_whenWillProduceCalled_closureCanBeSaved() throws {
+        var storedCompletion: ((Product) -> Void)?
+
+        given(mock)
+            .download(completion: .any)
+            .willProduce { completion in
+                storedCompletion = completion
+            }
+
+        mock.download { _ in }
+
+        XCTAssertNotNil(storedCompletion)
+    }
+
+    func test_givenInoutParam_whenWillProduceUsed_mutationWorks() {
+        given(mock)
+            .change(user: .any)
+            .willProduce { param in
+                param.age = 100
+            }
+        var user: User = .init(name: "test", age: 0)
+        mock.change(user: &user)
+
+        XCTAssertEqual(user.age, 100)
+    }
 }

--- a/Tests/MockableTests/Protocols/Models/User.swift
+++ b/Tests/MockableTests/Protocols/Models/User.swift
@@ -10,7 +10,7 @@ import Foundation
 struct User: Equatable, Hashable {
     let id = UUID()
     let name: String
-    let age: Int
+    var age: Int
 
     static let test1: User = .init(name: "test1", age: 1)
     static let test2: User = .init(name: "test2", age: 2)

--- a/Tests/MockableTests/Protocols/TestService.swift
+++ b/Tests/MockableTests/Protocols/TestService.swift
@@ -28,7 +28,9 @@ protocol TestService {
     func setUser(user: User) async throws -> Bool
     func modify(user: User) -> Int
     func update(products: [Product]) -> Int
+    func download(completion: @escaping (Product) -> Void)
     func print() throws
+    func change(user: inout User)
 
     // MARK: Generics
 


### PR DESCRIPTION
Up until this point, all attributes including `@escaping` were removed from function parameter types in the generated mock implementation to allow using them in other places than parameter positions. (ex.: enum cases)

This however is wrong when generating the producer resolver, that uses the function parameter types at closure parameter positions and needs to mark potential closure type parameters `@escaping`.

Also, `inout` was previously removed from closure parameters in the above process. This PR keeps it and adds support for `inout` types in `willProduce` clauses.