### PR TITLE
fix: support nonisolated keyword

### DIFF
--- a/Sources/MockableMacro/Factory/ConformanceFactory.swift
+++ b/Sources/MockableMacro/Factory/ConformanceFactory.swift
@@ -27,7 +27,7 @@ extension ConformanceFactory {
         try MemberBlockItemListSyntax {
             for variable in requirements.variables {
                 MemberBlockItemSyntax(
-                    decl: try variable.implement(with: requirements.modifiers)
+                    decl: try variable.implement(with: variable.syntax.modifiers)
                 )
             }
         }
@@ -37,7 +37,7 @@ extension ConformanceFactory {
         try MemberBlockItemListSyntax {
             for function in requirements.functions {
                 MemberBlockItemSyntax(
-                    decl: try function.implement(with: requirements.modifiers)
+                    decl: try function.implement(with: function.syntax.modifiers)
                 )
             }
         }

--- a/Sources/MockableMacro/Factory/Mockable/Function+Mockable.swift
+++ b/Sources/MockableMacro/Factory/Mockable/Function+Mockable.swift
@@ -13,7 +13,7 @@ extension FunctionRequirement: Mockable {
     func implement(with modifiers: DeclModifierListSyntax) throws -> DeclSyntax {
         let decl = FunctionDeclSyntax(
             attributes: syntax.attributes.trimmed.with(\.trailingTrivia, .newline),
-            modifiers: modifiers,
+            modifiers: modifiers.trimmed,
             funcKeyword: syntax.funcKeyword.trimmed,
             name: syntax.name.trimmed,
             genericParameterClause: syntax.genericParameterClause?.trimmed,

--- a/Sources/MockableMacro/Factory/Mockable/Variable+Mockable.swift
+++ b/Sources/MockableMacro/Factory/Mockable/Variable+Mockable.swift
@@ -13,7 +13,7 @@ extension VariableRequirement: Mockable {
     func implement(with modifiers: DeclModifierListSyntax) throws -> DeclSyntax {
         let variableDecl = VariableDeclSyntax(
             attributes: syntax.attributes.trimmed.with(\.trailingTrivia, .newline),
-            modifiers: modifiers,
+            modifiers: modifiers.trimmed,
             bindingSpecifier: .keyword(.var),
             bindings: try PatternBindingListSyntax {
                 try syntax.binding.with(\.accessorBlock, accessorBlock)

--- a/Tests/MockableTests/Protocols/TestProtocol.swift
+++ b/Tests/MockableTests/Protocols/TestProtocol.swift
@@ -34,6 +34,7 @@ protocol TestProtocol: Actor, Sendable where Item2: Identifiable {
     func asyncFunction() async
     func asyncThrowingFunction() async throws
     func asyncParamFunction(param: @escaping () async throws -> Void) async
+    nonisolated func nonisolatedFunction() async
 
     // MARK: Generic Functions
 
@@ -61,6 +62,7 @@ protocol TestProtocol: Actor, Sendable where Item2: Identifiable {
     var throwingProperty: Int { get throws }
     var asyncProperty: String { get async }
     var asyncThrowingProperty: String { get async throws }
+    nonisolated var nonisolatedProperty: String { get set }
 
     // MARK: Init
 


### PR DESCRIPTION
#75 

When calling implement for variables and functions, instead of passing requirements.modifiers, the respective modifiers for each variable and function are pass.