### PR TITLE
Fix name collisions

### DIFF
--- a/Sources/Mockable/Documentation/Documentation.docc/Usage.md
+++ b/Sources/Mockable/Documentation/Documentation.docc/Usage.md
@@ -197,14 +197,14 @@ You have two options to override the default strict behavior of the library:
     MockerPolicy.default = .relaxedVoid
     ```
 
-The `.relaxedMockable` policy in combination with the [`Mockable`](https://kolos65.github.io/Mockable/documentation/mockable/mockable) protocol can be used to set an implicit return value for custom (or even built in) types:
+The `.relaxedMocked` policy in combination with the [`Mocked`](https://kolos65.github.io/Mockable/documentation/mockable/mocked) protocol can be used to set an implicit return value for custom (or even built in) types:
 ```swift
 struct Car {
     var name: String
     var seats: Int
 }
 
-extension Car: Mockable {
+extension Car: Mocked {
     static var mock: Car {
         Car(name: "Mock Car", seats: 4)
     }
@@ -227,7 +227,7 @@ protocol CarService {
 
 func testCarService() {
     func test() {
-        let mock = MockCarService(policy: .relaxedMockable)
+        let mock = MockCarService(policy: .relaxedMocked)
         // Implictly mocked without a given registration:
         let car = mock.getCar()
         let cars = mock.getCars()

--- a/Sources/Mockable/Mocker/Mocked.swift
+++ b/Sources/Mockable/Mocker/Mocked.swift
@@ -1,13 +1,13 @@
 //
-//  Mockable.swift
-//  Mockable
+//  Mocked.swift
+//  Mocked
 //
 //  Created by Kolos Foltanyi on 2024. 04. 03..
 //
 
 /// A protocol that represents auto-mocked types.
 ///
-/// `Mockable` in combination with a `relaxedMockable` option of `MockerPolicy `can be used
+/// `Mocked` in combination with a `relaxedMocked` option of `MockerPolicy `can be used
 /// to set an implicit return value for custom types:
 ///
 /// ```swift
@@ -16,7 +16,7 @@
 ///     var seats: Int
 /// }
 ///
-/// extension Car: Mockable {
+/// extension Car: Mocked {
 ///     static var mock: Car {
 ///         Car(name: "Mock Car", seats: 4)
 ///     }
@@ -39,14 +39,14 @@
 ///
 /// func testCarService() {
 ///     func test() {
-///         let mock = MockCarService(policy: .relaxedMockable)
+///         let mock = MockCarService(policy: .relaxedMocked)
 ///         // Implictly mocked without a given registration:
 ///         let car = mock.getCar()
 ///         let cars = mock.getCars()
 ///     }
 /// }
 /// ```
-public protocol Mockable {
+public protocol Mocked {
     /// A default mock return value to use when `.relaxedMocked` policy is set.
     static var mock: Self { get }
 
@@ -55,16 +55,16 @@ public protocol Mockable {
     static var mocks: [Self] { get }
 }
 
-extension Mockable {
+extension Mocked {
     public static var mocks: [Self] { [mock] }
 }
 
-extension Array: Mockable where Element: Mockable {
+extension Array: Mocked where Element: Mocked {
     public static var mock: Self {
         Element.mocks
     }
 }
 
-extension Optional: Mockable where Wrapped: Mockable {
+extension Optional: Mocked where Wrapped: Mocked {
     public static var mock: Self { Wrapped.mock }
 }

--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -358,8 +358,8 @@ extension Mocker {
     public func mock<V>(
         _ member: Member,
         producerResolver: (Any) throws -> V
-    ) -> V where V: Mockable {
-        let relaxed = currentPolicy.contains(.relaxedMockable)
+    ) -> V where V: Mocked {
+        let relaxed = currentPolicy.contains(.relaxedMocked)
         // swiftlint:disable:next force_try
         return try! mock(member, producerResolver, relaxed ? .value(.mock) : .none)
     }
@@ -374,8 +374,8 @@ extension Mocker {
     public func mockThrowing<V>(
         _ member: Member,
         producerResolver: (Any) throws -> V
-    ) throws -> V where V: Mockable {
-        let relaxed = currentPolicy.contains(.relaxedMockable)
+    ) throws -> V where V: Mocked {
+        let relaxed = currentPolicy.contains(.relaxedMocked)
         return try mock(member, producerResolver, relaxed ? .value(.mock) : .none)
     }
 }
@@ -393,9 +393,9 @@ extension Mocker {
     public func mock<V>(
         _ member: Member,
         producerResolver: (Any) throws -> V
-    ) -> V where V: Mockable, V: ExpressibleByNilLiteral {
+    ) -> V where V: Mocked, V: ExpressibleByNilLiteral {
         // swiftlint:disable force_try
-        if currentPolicy.contains(.relaxedMockable) {
+        if currentPolicy.contains(.relaxedMocked) {
             return try! mock(member, producerResolver, .value(.mock))
         } else if currentPolicy.contains(.relaxedOptional) {
             return try! mock(member, producerResolver, .value(nil))
@@ -415,8 +415,8 @@ extension Mocker {
     public func mockThrowing<V>(
         _ member: Member,
         producerResolver: (Any) throws -> V
-    ) throws -> V where V: Mockable, V: ExpressibleByNilLiteral {
-        if currentPolicy.contains(.relaxedMockable) {
+    ) throws -> V where V: Mocked, V: ExpressibleByNilLiteral {
+        if currentPolicy.contains(.relaxedMocked) {
             return try mock(member, producerResolver, .value(.mock))
         } else if currentPolicy.contains(.relaxedOptional) {
             return try mock(member, producerResolver, .value(nil))

--- a/Sources/Mockable/Mocker/MockerPolicy.swift
+++ b/Sources/Mockable/Mocker/MockerPolicy.swift
@@ -23,7 +23,7 @@ public struct MockerPolicy: OptionSet {
         .relaxedOptional,
         .relaxedThrowingVoid,
         .relaxedNonThrowingVoid,
-        .relaxedMockable
+        .relaxedMocked
     ]
 
     /// Every void function will run normally without a registration
@@ -41,8 +41,8 @@ public struct MockerPolicy: OptionSet {
     /// Optional return values will default to nil.
     public static let relaxedOptional = Self(rawValue: 1 << 2)
 
-    /// Types conforming to the `Mockable` protocol will default to their mock value.
-    public static let relaxedMockable = Self(rawValue: 1 << 3)
+    /// Types conforming to the `Mocked` protocol will default to their mock value.
+    public static let relaxedMocked = Self(rawValue: 1 << 3)
 
     /// Option set raw value.
     public let rawValue: Int

--- a/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
@@ -86,7 +86,8 @@ extension FunctionRequirement {
             }
         }
         return ReturnClauseSyntax(
-            type: IdentifierTypeSyntax(
+            type: MemberTypeSyntax(
+                baseType: IdentifierTypeSyntax(name: NS.Mockable),
                 name: name,
                 genericArgumentClause: .init(arguments: arguments)
             )

--- a/Sources/MockableMacro/Factory/Buildable/Variable+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Variable+Buildable.swift
@@ -91,7 +91,7 @@ extension VariableRequirement {
     private func returnType(
         for kind: BuilderKind,
         using mockType: IdentifierTypeSyntax
-    ) throws -> IdentifierTypeSyntax {
+    ) throws -> MemberTypeSyntax {
         let name = if syntax.isComputed {
             try syntax.isThrowing ? NS.ThrowingFunction(kind) : NS.Function(kind)
         } else {
@@ -108,7 +108,9 @@ extension VariableRequirement {
                 produceType
             }
         }
-        return IdentifierTypeSyntax(
+
+        return MemberTypeSyntax(
+            baseType: IdentifierTypeSyntax(name: NS.Mockable),
             name: name,
             genericArgumentClause: .init(arguments: arguments)
         )

--- a/Sources/MockableMacro/Factory/BuilderFactory.swift
+++ b/Sources/MockableMacro/Factory/BuilderFactory.swift
@@ -37,8 +37,14 @@ extension BuilderFactory {
     }
 
     private static func inheritedTypes(_ kind: BuilderKind) -> InheritedTypeListSyntax {
-        let effectBuilder = IdentifierTypeSyntax(name: NS.EffectBuilder)
-        let assertionBuilder = IdentifierTypeSyntax(name: NS.AssertionBuilder)
+        let effectBuilder = MemberTypeSyntax(
+            baseType: IdentifierTypeSyntax(name: NS.Mockable),
+            name: NS.EffectBuilder
+        )
+        let assertionBuilder = MemberTypeSyntax(
+            baseType: IdentifierTypeSyntax(name: NS.Mockable),
+            name: NS.AssertionBuilder
+        )
         return [InheritedTypeSyntax(type: kind == .verify ? assertionBuilder : effectBuilder)]
     }
 
@@ -77,7 +83,7 @@ extension BuilderFactory {
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(identifier: NS.mocker),
-                    typeAnnotation: TypeAnnotationSyntax(type: mockerType(requirements))
+                    typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: NS.Mocker))
                 )
             }
         )
@@ -131,7 +137,10 @@ extension BuilderFactory {
     ) -> FunctionSignatureSyntax {
         FunctionSignatureSyntax(
             parameterClause: FunctionParameterClauseSyntax {
-                FunctionParameterSyntax(firstName: NS.mocker, type: mockerType(requirements))
+                FunctionParameterSyntax(
+                    firstName: NS.mocker,
+                    type: IdentifierTypeSyntax(name: NS.Mocker)
+                )
                 if kind == .verify {
                     FunctionParameterSyntax(
                         firstName: NS.assertion,
@@ -142,16 +151,10 @@ extension BuilderFactory {
         )
     }
 
-    private static func mockerType(_ requirements: Requirements) -> IdentifierTypeSyntax {
-        IdentifierTypeSyntax(
-            name: NS.Mocker,
-            genericArgumentClause: GenericArgumentClauseSyntax(arguments: [
-                GenericArgumentSyntax(argument: requirements.syntax.mockType)
-            ])
+    private static var assertionType: MemberTypeSyntax {
+        MemberTypeSyntax(
+            baseType: IdentifierTypeSyntax(name: NS.Mockable),
+            name: NS.MockableAssertion
         )
-    }
-
-    private static var assertionType: IdentifierTypeSyntax {
-        IdentifierTypeSyntax(name: NS.MockableAssertion)
     }
 }

--- a/Sources/MockableMacro/Factory/EnumFactory.swift
+++ b/Sources/MockableMacro/Factory/EnumFactory.swift
@@ -27,8 +27,18 @@ enum EnumFactory: Factory {
 extension EnumFactory {
     private static var inheritanceClause: InheritanceClauseSyntax {
         InheritanceClauseSyntax {
-            InheritedTypeSyntax(type: IdentifierTypeSyntax(name: NS.Matchable))
-            InheritedTypeSyntax(type: IdentifierTypeSyntax(name: NS.CaseIdentifiable))
+            InheritedTypeSyntax(
+                type: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(name: NS.Mockable),
+                    name: NS.Matchable
+                )
+            )
+            InheritedTypeSyntax(
+                type: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(name: NS.Mockable),
+                    name: NS.CaseIdentifiable
+                )
+            )
         }
     }
 

--- a/Sources/MockableMacro/Factory/MemberFactory.swift
+++ b/Sources/MockableMacro/Factory/MemberFactory.swift
@@ -14,6 +14,7 @@ import SwiftSyntax
 enum MemberFactory: Factory {
     static func build(from requirements: Requirements) throws -> MemberBlockItemListSyntax {
         MemberBlockItemListSyntax {
+            mockerAlias(requirements)
             mocker(requirements)
             given(requirements)
             when(requirements)
@@ -35,6 +36,24 @@ extension MemberFactory {
         )
     }
 
+    private static func mockerAlias(_ requirements: Requirements) -> TypeAliasDeclSyntax {
+        TypeAliasDeclSyntax(
+            modifiers: requirements.modifiers,
+            name: NS.Mocker,
+            initializer: TypeInitializerClauseSyntax(
+                value: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(name: NS.Mockable),
+                    name: NS.Mocker,
+                    genericArgumentClause: GenericArgumentClauseSyntax(
+                        arguments: GenericArgumentListSyntax {
+                            GenericArgumentSyntax(argument: requirements.syntax.mockType)
+                        }
+                    )
+                )
+            )
+        )
+    }
+
     private static func mocker(_ requirements: Requirements) -> VariableDeclSyntax {
         VariableDeclSyntax(
             modifiers: [DeclModifierSyntax(name: .keyword(.private))],
@@ -44,14 +63,7 @@ extension MemberFactory {
                 pattern: IdentifierPatternSyntax(identifier: NS.mocker),
                 initializer: InitializerClauseSyntax(
                     value: FunctionCallExprSyntax(
-                        calledExpression: GenericSpecializationExprSyntax(
-                            expression: DeclReferenceExprSyntax(baseName: NS.Mocker),
-                            genericArgumentClause: GenericArgumentClauseSyntax(
-                                arguments: GenericArgumentListSyntax {
-                                    GenericArgumentSyntax(argument: requirements.syntax.mockType)
-                                }
-                            )
-                        ),
+                        calledExpression: DeclReferenceExprSyntax(baseName: NS.Mocker),
                         leftParen: .leftParenToken(),
                         arguments: [],
                         rightParen: .rightParenToken()
@@ -164,7 +176,10 @@ extension MemberFactory {
             secondName: NS.assertion,
             type: AttributedTypeSyntax(
                 attributes: [.attribute(.escaping)],
-                baseType: IdentifierTypeSyntax(name: NS.MockableAssertion)
+                baseType: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(name: NS.Mockable),
+                    name: NS.MockableAssertion
+                )
             )
         )
     }
@@ -178,7 +193,8 @@ extension MemberFactory {
                 genericArgumentClause: GenericArgumentClauseSyntax(
                     arguments: GenericArgumentListSyntax {
                         GenericArgumentSyntax(
-                            argument: IdentifierTypeSyntax(
+                            argument: MemberTypeSyntax(
+                                baseType: IdentifierTypeSyntax(name: NS.Mockable),
                                 name: NS.MockerScope
                             )
                         )
@@ -246,7 +262,10 @@ extension MemberFactory {
                 FunctionParameterSyntax(
                     firstName: NS.policy,
                     type: OptionalTypeSyntax(
-                        wrappedType: IdentifierTypeSyntax(name: NS.MockerPolicy)
+                        wrappedType: MemberTypeSyntax(
+                            baseType: IdentifierTypeSyntax(name: NS.Mockable),
+                            name: NS.MockerPolicy
+                        )
                     ),
                     defaultValue: InitializerClauseSyntax(
                         value: NilLiteralExprSyntax()

--- a/Sources/MockableMacro/Factory/MockFactory.swift
+++ b/Sources/MockableMacro/Factory/MockFactory.swift
@@ -60,9 +60,12 @@ extension MockFactory {
             InheritedTypeSyntax(type: IdentifierTypeSyntax(
                 name: requirements.syntax.name.trimmed
             ))
-            InheritedTypeSyntax(type: IdentifierTypeSyntax(
-                name: NS.MockableService
-            ))
+            InheritedTypeSyntax(
+                type: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(name: NS.Mockable),
+                    name: NS.MockableService
+                )
+            )
         }
     }
 

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -56,6 +56,7 @@ enum NS {
     static let mocker: TokenSyntax = "mocker"
     static let assertion: TokenSyntax = "assertion"
 
+    static let Mockable: TokenSyntax = "Mockable"
     static let Mock: TokenSyntax = "Mock"
     static let MockableService: TokenSyntax = "MockableService"
     static let Bool: TokenSyntax = "Bool"

--- a/Tests/MockableMacroTests/AccessModifierTests.swift
+++ b/Tests/MockableMacroTests/AccessModifierTests.swift
@@ -30,8 +30,9 @@ final class AccessModifierTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            public final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            public final class MockTest: Test, Mockable.MockableService {
+                public typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 public func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -41,13 +42,13 @@ final class AccessModifierTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                public func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                public func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                public func reset(_ scopes: Set<MockerScope> = .all) {
+                public func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                public init(policy: MockerPolicy? = nil) {
+                public init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -70,7 +71,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                public enum Member: Matchable, CaseIdentifiable {
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
                     public func match(_ other: Member) -> Bool {
@@ -84,41 +85,41 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                public struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    public init(mocker: Mocker<MockTest>) {
+                public struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    public init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public var foo: FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    public var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    public func bar(number: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    public func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
-                public struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    public init(mocker: Mocker<MockTest>) {
+                public struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    public init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public var foo: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    public var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    public func bar(number: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    public func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
-                public struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    public init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                public struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    public init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    public var foo: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    public var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo, assertion: assertion)
                     }
-                    public func bar(number: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    public func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_bar(number: number), assertion: assertion)
                     }
                 }
@@ -145,8 +146,9 @@ final class AccessModifierTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            private final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            private final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -156,13 +158,13 @@ final class AccessModifierTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -183,7 +185,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
                     func match(_ other: Member) -> Bool {
@@ -197,41 +199,41 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    func bar(number: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    func bar(number: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var foo: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo, assertion: assertion)
                     }
-                    func bar(number: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_bar(number: number), assertion: assertion)
                     }
                 }
@@ -256,8 +258,9 @@ final class AccessModifierTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            public final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            public final class MockTest: Test, Mockable.MockableService {
+                public typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 public func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -267,13 +270,13 @@ final class AccessModifierTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                public func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                public func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                public func reset(_ scopes: Set<MockerScope> = .all) {
+                public func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                public init(policy: MockerPolicy? = nil) {
+                public init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -285,7 +288,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                public enum Member: Matchable, CaseIdentifiable {
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo
                     public func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -294,32 +297,32 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                public struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    public init(mocker: Mocker<MockTest>) {
+                public struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    public init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public func foo() -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
+                    public func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
-                public struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    public init(mocker: Mocker<MockTest>) {
+                public struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    public init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public func foo() -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    public func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
-                public struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    public init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                public struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    public init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    public func foo() -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    public func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo, assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/ActorConformanceTests.swift
+++ b/Tests/MockableMacroTests/ActorConformanceTests.swift
@@ -32,8 +32,9 @@ final class ActorConformanceTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            actor MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            actor MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 nonisolated func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -43,13 +44,13 @@ final class ActorConformanceTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                nonisolated func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                nonisolated func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -86,7 +87,7 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo
                     case m2_quz
                     case m3_bar(number: Parameter<Int>)
@@ -106,59 +107,59 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    var quz: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    func baz(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m4_baz(number: number))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var quz: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func baz(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m4_baz(number: number))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var foo: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo, assertion: assertion)
                     }
-                    var quz: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var quz: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_quz, assertion: assertion)
                     }
-                    func bar(number: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_bar(number: number), assertion: assertion)
                     }
-                    func baz(number: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func baz(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m4_baz(number: number), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -26,8 +26,9 @@ final class AssociatedTypeTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest<Item>: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest<Item>: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -37,13 +38,13 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -55,7 +56,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -64,32 +65,32 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item), assertion: assertion)
                     }
                 }
@@ -116,8 +117,9 @@ final class AssociatedTypeTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest<Item>: Test, MockableService where Item: Equatable, Item: Hashable {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest<Item>: Test, Mockable.MockableService where Item: Equatable, Item: Hashable {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -127,13 +129,13 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -145,7 +147,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -154,32 +156,32 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item), assertion: assertion)
                     }
                 }
@@ -206,8 +208,9 @@ final class AssociatedTypeTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest<Item>: Test, MockableService where Item: Equatable, Item: Hashable {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest<Item>: Test, Mockable.MockableService where Item: Equatable, Item: Hashable {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -217,13 +220,13 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -235,7 +238,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -244,32 +247,32 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo(item: Parameter<Item>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/AttributesTests.swift
+++ b/Tests/MockableMacroTests/AttributesTests.swift
@@ -50,8 +50,9 @@ final class AttributesTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockAttributeTest: AttributeTest, MockableService {
-                private let mocker = Mocker<MockAttributeTest>()
+            final class MockAttributeTest: AttributeTest, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockAttributeTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -61,13 +62,13 @@ final class AttributesTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -114,7 +115,7 @@ final class AttributesTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_prop
                     case m2_prop2
                     case m3_test
@@ -134,71 +135,71 @@ final class AttributesTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockAttributeTest>
-                    init(mocker: Mocker<MockAttributeTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     @available(iOS 15, *)
-                    var prop: FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
+                    var prop: Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_prop)
                     }
                     @available(iOS 15, *)
-                    var prop2: FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
+                    var prop2: Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m2_prop2)
                     }
                     @available(iOS 15, *)
-                    func test() -> FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
+                    func test() -> Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m3_test)
                     }
                     @available(iOS 15, *)
-                    func test2() -> FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
+                    func test2() -> Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m4_test2)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockAttributeTest>
-                    init(mocker: Mocker<MockAttributeTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     @available(iOS 15, *)
-                    var prop: FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    var prop: Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                     @available(iOS 15, *)
-                    var prop2: FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    var prop2: Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m2_prop2)
                     }
                     @available(iOS 15, *)
-                    func test() -> FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    func test() -> Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m3_test)
                     }
                     @available(iOS 15, *)
-                    func test2() -> FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    func test2() -> Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m4_test2)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockAttributeTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockAttributeTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
                     @available(iOS 15, *)
-                    var prop: FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    var prop: Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_prop, assertion: assertion)
                     }
                     @available(iOS 15, *)
-                    var prop2: FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    var prop2: Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_prop2, assertion: assertion)
                     }
                     @available(iOS 15, *)
-                    func test() -> FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    func test() -> Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_test, assertion: assertion)
                     }
                     @available(iOS 15, *)
-                    func test2() -> FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    func test2() -> Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m4_test2, assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -24,8 +24,9 @@ final class ExoticParameterTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -35,13 +36,13 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -53,7 +54,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(&value)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_modifyValue(Parameter<Int>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -62,32 +63,32 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (inout Int) -> Void> {
+                    func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (inout Int) -> Void> {
                         .init(mocker, kind: .m1_modifyValue(value))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_modifyValue(value))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_modifyValue(value), assertion: assertion)
                     }
                 }
@@ -112,8 +113,9 @@ final class ExoticParameterTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -123,13 +125,13 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -141,7 +143,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(values)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_printValues(Parameter<[Int]>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -150,32 +152,32 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ([Int]) -> Void> {
+                    func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ([Int]) -> Void> {
                         .init(mocker, kind: .m1_printValues(values))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_printValues(values))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_printValues(values), assertion: assertion)
                     }
                 }
@@ -200,8 +202,9 @@ final class ExoticParameterTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -211,13 +214,13 @@ final class ExoticParameterTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -229,7 +232,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -238,32 +241,32 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
+                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -27,8 +27,9 @@ final class FunctionEffectTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -38,13 +39,13 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -63,7 +64,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer()
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_returnsAndThrows
                     case m2_canThrowError
                     func match(_ other: Member) -> Bool {
@@ -77,41 +78,41 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func returnsAndThrows() -> ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, () throws -> String> {
+                    func returnsAndThrows() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, () throws -> String> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    func canThrowError() -> ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, () throws -> Void> {
+                    func canThrowError() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, () throws -> Void> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func returnsAndThrows() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func returnsAndThrows() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    func canThrowError() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func canThrowError() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func returnsAndThrows() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func returnsAndThrows() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_returnsAndThrows, assertion: assertion)
                     }
-                    func canThrowError() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func canThrowError() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_canThrowError, assertion: assertion)
                     }
                 }
@@ -136,8 +137,9 @@ final class FunctionEffectTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -147,13 +149,13 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -165,7 +167,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -174,32 +176,32 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
+                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation), assertion: assertion)
                     }
                 }
@@ -228,8 +230,9 @@ final class FunctionEffectTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -239,13 +242,13 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -271,7 +274,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer(param)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_asyncFunction
                     case m2_asyncThrowingFunction
                     case m3_asyncParamFunction(param: Parameter<() async throws -> Void>)
@@ -288,50 +291,50 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func asyncFunction() -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
+                    func asyncFunction() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    func asyncThrowingFunction() -> ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, () throws -> Void> {
+                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, () throws -> Void> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () async throws -> Void) throws -> Void> {
+                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () async throws -> Void) throws -> Void> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func asyncFunction() -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func asyncFunction() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    func asyncThrowingFunction() -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func asyncFunction() -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func asyncFunction() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_asyncFunction, assertion: assertion)
                     }
-                    func asyncThrowingFunction() -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_asyncThrowingFunction, assertion: assertion)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -24,8 +24,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -35,13 +36,13 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -53,7 +54,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo(item: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -62,32 +63,32 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ((Array<[(Set<T>, String)]>, Int)) -> Void> {
+                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ((Array<[(Set<T>, String)]>, Int)) -> Void> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()), assertion: assertion)
                     }
                 }
@@ -112,8 +113,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -123,13 +125,13 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -141,7 +143,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_genericFunc(item: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -150,32 +152,32 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func genericFunc<T, V>(item: Parameter<T>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, V, (T) -> V> {
+                    func genericFunc<T, V>(item: Parameter<T>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, V, (T) -> V> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func genericFunc<T>(item: Parameter<T>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func genericFunc<T>(item: Parameter<T>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func genericFunc<T>(item: Parameter<T>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func genericFunc<T>(item: Parameter<T>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()), assertion: assertion)
                     }
                 }
@@ -204,8 +206,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -215,13 +218,13 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -236,7 +239,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(p1, p2, p3, p4)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_method1(p1: Parameter<GenericValue>, p2: Parameter<GenericValue>, p3: Parameter<GenericValue>, p4: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -245,37 +248,37 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     func method1<T: Hashable, E, C, I>(
-                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (T, E, C, I) -> Void> where E: Equatable, E: Hashable, C: Codable {
+                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (T, E, C, I) -> Void> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     func method1<T: Hashable, E, C, I>(
-                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> FunctionActionBuilder<MockTest, ActionBuilder> where E: Equatable, E: Hashable, C: Codable {
+                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
                     func method1<T: Hashable, E, C, I>(
-                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> where E: Equatable, E: Hashable, C: Codable {
+                            p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()), assertion: assertion)
                     }
@@ -302,8 +305,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
 
             #if MOCKING
             @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -313,13 +317,13 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -333,7 +337,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_prop
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -342,32 +346,32 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<String>, () -> any SomeProtocol<String>> {
+                    var prop: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<String>, () -> any SomeProtocol<String>> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var prop: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var prop: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var prop: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_prop, assertion: assertion)
                     }
                 }
@@ -393,8 +397,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
 
             #if MOCKING
             @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -404,13 +409,13 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -424,7 +429,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_prop
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -433,32 +438,32 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
+                    var prop: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var prop: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var prop: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var prop: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_prop, assertion: assertion)
                     }
                 }
@@ -484,8 +489,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
 
             #if MOCKING
             @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -495,13 +501,13 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -513,7 +519,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -522,32 +528,32 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<Double>, () -> any SomeProtocol<Double>> {
+                    func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<Double>, () -> any SomeProtocol<Double>> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo() -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo, assertion: assertion)
                     }
                 }
@@ -573,8 +579,9 @@ final class GenericFunctionTests: MockableMacroTestCase {
 
             #if MOCKING
             @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -584,13 +591,13 @@ final class GenericFunctionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -602,7 +609,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -611,32 +618,32 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
+                    func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func foo() -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo, assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -26,8 +26,9 @@ final class InitRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -37,13 +38,13 @@ final class InitRequirementTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -52,28 +53,28 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name: String) {
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
@@ -103,8 +104,9 @@ final class InitRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -114,13 +116,13 @@ final class InitRequirementTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -131,28 +133,28 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name value: String, _ index: Int) {
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -26,8 +26,9 @@ final class NameCollisionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -37,13 +38,13 @@ final class NameCollisionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -62,7 +63,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_fetchData(for: Parameter<Int>)
                     case m2_fetchData(for: Parameter<String>)
                     func match(_ other: Member) -> Bool {
@@ -76,41 +77,41 @@ final class NameCollisionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(for name: Parameter<Int>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Int) -> String> {
+                    func fetchData(for name: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Int) -> String> {
                         .init(mocker, kind: .m1_fetchData(for: name))
                     }
-                    func fetchData(for name: Parameter<String>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
+                    func fetchData(for name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
                         .init(mocker, kind: .m2_fetchData(for: name))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(for name: Parameter<Int>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(for name: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_fetchData(for: name))
                     }
-                    func fetchData(for name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(for name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_fetchData(for: name))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func fetchData(for name: Parameter<Int>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(for name: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_fetchData(for: name), assertion: assertion)
                     }
-                    func fetchData(for name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(for name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_fetchData(for: name), assertion: assertion)
                     }
                 }
@@ -137,8 +138,9 @@ final class NameCollisionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -148,13 +150,13 @@ final class NameCollisionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -173,7 +175,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_fetchData(forA: Parameter<String>)
                     case m2_fetchData(forB: Parameter<String>)
                     func match(_ other: Member) -> Bool {
@@ -187,41 +189,41 @@ final class NameCollisionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(forA name: Parameter<String>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
+                    func fetchData(forA name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
                         .init(mocker, kind: .m1_fetchData(forA: name))
                     }
-                    func fetchData(forB name: Parameter<String>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
+                    func fetchData(forB name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
                         .init(mocker, kind: .m2_fetchData(forB: name))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(forA name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(forA name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_fetchData(forA: name))
                     }
-                    func fetchData(forB name: Parameter<String>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func fetchData(forB name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_fetchData(forB: name))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func fetchData(forA name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(forA name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_fetchData(forA: name), assertion: assertion)
                     }
-                    func fetchData(forB name: Parameter<String>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func fetchData(forB name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_fetchData(forB: name), assertion: assertion)
                     }
                 }
@@ -246,8 +248,9 @@ final class NameCollisionTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -257,13 +260,13 @@ final class NameCollisionTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -275,7 +278,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(param)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_repeat(param: Parameter<Bool>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -284,32 +287,32 @@ final class NameCollisionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func `repeat`(param: Parameter<Bool>) -> FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Bool) -> String> {
+                    func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Bool) -> String> {
                         .init(mocker, kind: .m1_repeat(param: param))
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func `repeat`(param: Parameter<Bool>) -> FunctionActionBuilder<MockTest, ActionBuilder> {
+                    func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_repeat(param: param))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func `repeat`(param: Parameter<Bool>) -> FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_repeat(param: param), assertion: assertion)
                     }
                 }

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -26,8 +26,9 @@ final class PropertyRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -37,13 +38,13 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -66,7 +67,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_computedInt
                     case m2_computedString
                     func match(_ other: Member) -> Bool {
@@ -80,41 +81,41 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var computedInt: FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    var computedInt: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_computedInt)
                     }
-                    var computedString: FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
+                    var computedString: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
                         .init(mocker, kind: .m2_computedString)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var computedInt: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var computedInt: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_computedInt)
                     }
-                    var computedString: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var computedString: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_computedString)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var computedInt: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var computedInt: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_computedInt, assertion: assertion)
                     }
-                    var computedString: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var computedString: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_computedString, assertion: assertion)
                     }
                 }
@@ -141,8 +142,9 @@ final class PropertyRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -152,13 +154,13 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -191,7 +193,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         mocker.performActions(for: member)
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_get_mutableInt
                     case m1_set_mutableInt(newValue: Parameter<Int>)
                     case m2_get_mutableString
@@ -211,41 +213,41 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var mutableInt: PropertyReturnBuilder<MockTest, ReturnBuilder, Int> {
+                    var mutableInt: Mockable.PropertyReturnBuilder<MockTest, ReturnBuilder, Int> {
                         .init(mocker, kind: .m1_get_mutableInt)
                     }
-                    var mutableString: PropertyReturnBuilder<MockTest, ReturnBuilder, String> {
+                    var mutableString: Mockable.PropertyReturnBuilder<MockTest, ReturnBuilder, String> {
                         .init(mocker, kind: .m2_get_mutableString)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func mutableInt(newValue: Parameter<Int> = .any) -> PropertyActionBuilder<MockTest, ActionBuilder> {
+                    func mutableInt(newValue: Parameter<Int> = .any) -> Mockable.PropertyActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_get_mutableInt, setKind: .m1_set_mutableInt(newValue: newValue))
                     }
-                    func mutableString(newValue: Parameter<String> = .any) -> PropertyActionBuilder<MockTest, ActionBuilder> {
+                    func mutableString(newValue: Parameter<String> = .any) -> Mockable.PropertyActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_get_mutableString, setKind: .m2_set_mutableString(newValue: newValue))
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    func mutableInt(newValue: Parameter<Int> = .any) -> PropertyVerifyBuilder<MockTest, VerifyBuilder> {
+                    func mutableInt(newValue: Parameter<Int> = .any) -> Mockable.PropertyVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_get_mutableInt, setKind: .m1_set_mutableInt(newValue: newValue), assertion: assertion)
                     }
-                    func mutableString(newValue: Parameter<String> = .any) -> PropertyVerifyBuilder<MockTest, VerifyBuilder> {
+                    func mutableString(newValue: Parameter<String> = .any) -> Mockable.PropertyVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_get_mutableString, setKind: .m2_set_mutableString(newValue: newValue), assertion: assertion)
                     }
                 }
@@ -274,8 +276,9 @@ final class PropertyRequirementTests: MockableMacroTestCase {
             }
 
             #if MOCKING
-            final class MockTest: Test, MockableService {
-                private let mocker = Mocker<MockTest>()
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
                 @available(*, deprecated, message: "Use given(_ service:) of Mockable instead. ")
                 func given() -> ReturnBuilder {
                     .init(mocker: mocker)
@@ -285,13 +288,13 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                     .init(mocker: mocker)
                 }
                 @available(*, deprecated, message: "Use verify(_ service:) of MockableTest instead. ")
-                func verify(with assertion: @escaping MockableAssertion) -> VerifyBuilder {
+                func verify(with assertion: @escaping Mockable.MockableAssertion) -> VerifyBuilder {
                     .init(mocker: mocker, assertion: assertion)
                 }
-                func reset(_ scopes: Set<MockerScope> = .all) {
+                func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
                     mocker.reset(scopes: scopes)
                 }
-                init(policy: MockerPolicy? = nil) {
+                init(policy: Mockable.MockerPolicy? = nil) {
                     if let policy {
                         mocker.policy = policy
                     }
@@ -323,7 +326,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Matchable, CaseIdentifiable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable {
                     case m1_throwingProperty
                     case m2_asyncProperty
                     case m3_asyncThrowingProperty
@@ -340,50 +343,50 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                struct ReturnBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ReturnBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var throwingProperty: ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Int, () throws -> Int> {
+                    var throwingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Int, () throws -> Int> {
                         .init(mocker, kind: .m1_throwingProperty)
                     }
-                    var asyncProperty: FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
+                    var asyncProperty: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
                         .init(mocker, kind: .m2_asyncProperty)
                     }
-                    var asyncThrowingProperty: ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, () throws -> String> {
+                    var asyncThrowingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, () throws -> String> {
                         .init(mocker, kind: .m3_asyncThrowingProperty)
                     }
                 }
-                struct ActionBuilder: EffectBuilder {
-                    private let mocker: Mocker<MockTest>
-                    init(mocker: Mocker<MockTest>) {
+                struct ActionBuilder: Mockable.EffectBuilder {
+                    private let mocker: Mocker
+                    init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var throwingProperty: ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    var throwingProperty: Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_throwingProperty)
                     }
-                    var asyncProperty: FunctionActionBuilder<MockTest, ActionBuilder> {
+                    var asyncProperty: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_asyncProperty)
                     }
-                    var asyncThrowingProperty: ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    var asyncThrowingProperty: Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m3_asyncThrowingProperty)
                     }
                 }
-                struct VerifyBuilder: AssertionBuilder {
-                    private let mocker: Mocker<MockTest>
-                    private let assertion: MockableAssertion
-                    init(mocker: Mocker<MockTest>, assertion: @escaping MockableAssertion) {
+                struct VerifyBuilder: Mockable.AssertionBuilder {
+                    private let mocker: Mocker
+                    private let assertion: Mockable.MockableAssertion
+                    init(mocker: Mocker, assertion: @escaping Mockable.MockableAssertion) {
                         self.mocker = mocker
                         self.assertion = assertion
                     }
-                    var throwingProperty: ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var throwingProperty: Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_throwingProperty, assertion: assertion)
                     }
-                    var asyncProperty: FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var asyncProperty: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_asyncProperty, assertion: assertion)
                     }
-                    var asyncThrowingProperty: ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    var asyncThrowingProperty: Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_asyncThrowingProperty, assertion: assertion)
                     }
                 }

--- a/Tests/MockableTests/PolicyTests.swift
+++ b/Tests/MockableTests/PolicyTests.swift
@@ -13,7 +13,7 @@ public struct Car: Equatable {
     var seats: Int
 }
 
-extension Car: Mockable {
+extension Car: Mocked {
     public static var mock: Car {
         Car(name: "Mock", seats: 4)
     }
@@ -70,7 +70,7 @@ final class PolicyTests: XCTestCase {
     }
 
     func test_whenCustomMockedPolicySet_mockReturnsDefault() throws {
-        let mock = MockPolicyService(policy: .relaxedMockable)
+        let mock = MockPolicyService(policy: .relaxedMocked)
         XCTAssertEqual(Car.mock, mock.carFunc())
         XCTAssertEqual(Car.mock, mock.optionalCarFunc())
         XCTAssertEqual(Car.mock, mock.carProp)


### PR DESCRIPTION
To avoid any future name collisions, this PR updates the macro to use fully qualified identifiers in macro generated code. In order to avoid name collision between the module `Mockable` and the existing `Mockable` protocol, it was renamed to `Mocked`.

Thanks @wvteijlingen-npo for the issue and the solution idea. 🎉