### PR TITLE
Leverage CI to ensure Mockable works on Linux with the supported Swift versions and enhance the DX

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: ["5.9", "6.0"]
+        swift: ["5", "6"]
     env:
       MOCKABLE_TEST: true
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: pull-request-validation
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   lint:
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: "14"
 
       - name: Install commitlint
         run: npm install -g @commitlint/cli@11.0.0 @commitlint/config-conventional@11.0.0
@@ -66,11 +66,17 @@ jobs:
   test-linux:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        swift: ["5.9", "6.0"]
     env:
       MOCKABLE_TEST: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: ${{ matrix.swift }}
       - name: Run Tests
         run: |
           Scripts/test.sh

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -2,5 +2,21 @@
 
 set -eo pipefail
 
-swift build
-swift test
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+source $ROOT_DIR/Scripts/utils.sh
+
+# When --vm is passed, the build and test commands are executed in a virtualized container.
+if [[ " $* " == *" --vm "* ]]; then
+    CONTAINER_RUNTIME=$(get_container_runtime)
+    $CONTAINER_RUNTIME run --rm \
+        --volume "$ROOT_DIR:/package" \
+        --workdir "/package" \
+        -e MOCKABLE_TEST=$MOCKABLE_TEST \
+        swiftlang/swift:nightly-6.1-focal \
+        /bin/bash -c \
+        "swift build --build-path ./.build/linux"
+else
+    swift build --package-path "$ROOT_DIR"
+    swift test --package-path "$ROOT_DIR"
+fi

--- a/Scripts/utils.sh
+++ b/Scripts/utils.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Function to determine the container runtime
+get_container_runtime() {
+    if command -v podman &> /dev/null; then
+        echo "podman"
+    elif command -v docker &> /dev/null; then
+        echo "docker"
+    else
+        echo "Neither podman nor docker is installed. Please install one of them to proceed." >&2
+        exit 1
+    fi
+}


### PR DESCRIPTION
I noticed the GitHub Actions workflow that tests Mockable on Linux doesn't specify any Linux version, making the workflow non-deterministic. I adjusted to explicitly install the versions that the workflow tests against.

I took the opportunity to improve the `Scripts/test.sh` script to support passing a `--vm` option. Thanks to that, someone can run the tests on Linux from a macOS environment using virtualization technologies like Docker & Podman.