### PR TITLE
Fails to compile with Swift 6.1 

### DIFF
--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -34,7 +34,7 @@ public class Mocker<Service: MockableService>: @unchecked Sendable {
     /// Array to store invocations of members.
     private lazy var invocations = LockIsolated<[Member]>([]) { newValue in
         Task {
-            #if swift(>=6)
+            #if swift(>=6.0) && !swift(>=6.1)
             self.invocationsSubject.send(newValue)
             #else
             await self.invocationsSubject.send(newValue)


### PR DESCRIPTION
It looks like a Swift change was reverted or refined in Swift 6.1 (included in Xcode 16.3 Beta 1) and Mockable no longer compiles. This PR applies the conditional only to version 6 but no longer to version 6.1 so the project compiles again.

<img width="1155" alt="Screenshot 2025-02-24 at 15 50 13" src="https://github.com/user-attachments/assets/87fc892e-f172-4980-ac5e-7228ebd0ae7b" />
