### PR TITLE
Adding Swift base type to Sendable inherited type definition

### DIFF
--- a/Sources/MockableMacro/Factory/EnumFactory.swift
+++ b/Sources/MockableMacro/Factory/EnumFactory.swift
@@ -40,7 +40,10 @@ extension EnumFactory {
                 )
             )
             InheritedTypeSyntax(
-                type: IdentifierTypeSyntax(name: NS.Sendable)
+                type: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(name: NS.Swift),
+                    name: NS.Sendable
+                )
             )
         }
     }

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -81,6 +81,7 @@ enum NS {
     static let Error: TokenSyntax = "Error"
     static let NSObjectProtocol: String = "NSObjectProtocol"
     static let NSObject: TokenSyntax = "NSObject"
+    static let Swift: TokenSyntax = "Swift"
     static let Sendable: TokenSyntax = "Sendable"
 
     static func Parameter(_ type: String) -> TokenSyntax { "Parameter<\(raw: type)>" }

--- a/Tests/MockableMacroTests/AccessModifierTests.swift
+++ b/Tests/MockableMacroTests/AccessModifierTests.swift
@@ -71,7 +71,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
                     public func match(_ other: Member) -> Bool {
@@ -183,7 +183,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
                     func match(_ other: Member) -> Bool {
@@ -284,7 +284,7 @@ final class AccessModifierTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     public func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/ActorConformanceTests.swift
+++ b/Tests/MockableMacroTests/ActorConformanceTests.swift
@@ -89,7 +89,7 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_quz
                     case m3_bar(number: Parameter<Int>)
@@ -244,7 +244,7 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_quz
                     case m3_bar(number: Parameter<Int>)

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -56,7 +56,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -145,7 +145,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -234,7 +234,7 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<Item>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/AttributesTests.swift
+++ b/Tests/MockableMacroTests/AttributesTests.swift
@@ -115,7 +115,7 @@ final class AttributesTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_prop
                     case m2_prop2
                     case m3_test

--- a/Tests/MockableMacroTests/DocCommentsTests.swift
+++ b/Tests/MockableMacroTests/DocCommentsTests.swift
@@ -62,7 +62,7 @@ final class DocCommentsTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -54,7 +54,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(&value)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_modifyValue(Parameter<Int>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -141,7 +141,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(values)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_printValues(Parameter<[Int]>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -228,7 +228,7 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -63,7 +63,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_returnsAndThrows
                     case m2_canThrowError
                     func match(_ other: Member) -> Bool {
@@ -164,7 +164,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -269,7 +269,7 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer(param)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_asyncFunction
                     case m2_asyncThrowingFunction
                     case m3_asyncParamFunction(param: Parameter<() async throws -> Void>)

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -54,7 +54,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -141,7 +141,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_genericFunc(item: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -235,7 +235,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(p1, p2, p3, p4)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_method1(p1: Parameter<GenericValue>, p2: Parameter<GenericValue>, p3: Parameter<GenericValue>, p4: Parameter<GenericValue>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -331,7 +331,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_prop
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -421,7 +421,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_prop
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -509,7 +509,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
@@ -597,7 +597,7 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/InheritedTypeMappingTests.swift
+++ b/Tests/MockableMacroTests/InheritedTypeMappingTests.swift
@@ -54,7 +54,7 @@ final class InheritedTypeMappingTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -53,7 +53,7 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name: String) {
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }
@@ -131,7 +131,7 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name value: String, _ index: Int) {
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -63,7 +63,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_fetchData(for: Parameter<Int>)
                     case m2_fetchData(for: Parameter<String>)
                     func match(_ other: Member) -> Bool {
@@ -173,7 +173,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_fetchData(forA: Parameter<String>)
                     case m2_fetchData(forB: Parameter<String>)
                     func match(_ other: Member) -> Bool {
@@ -274,7 +274,7 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(param)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_repeat(param: Parameter<Bool>)
                     func match(_ other: Member) -> Bool {
                         switch (self, other) {

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -67,7 +67,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_computedInt
                     case m2_computedString
                     func match(_ other: Member) -> Bool {
@@ -191,7 +191,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         mocker.performActions(for: member)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_get_mutableInt
                     case m1_set_mutableInt(newValue: Parameter<Int>)
                     case m2_get_mutableString
@@ -322,7 +322,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_throwingProperty
                     case m2_asyncProperty
                     case m3_asyncThrowingProperty

--- a/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
+++ b/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
@@ -68,7 +68,7 @@ final class TypedThrowsTests_Swift6: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Sendable {
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_baz
                     case m2_foo
                     func match(_ other: Member) -> Bool {


### PR DESCRIPTION
This solves a pretty niche issue I ran into when using Mockable in conjunction with [Bluejay](https://github.com/steamclock/bluejay), a bluetooth low energy library. 

Bluejay has its own `Sendable` type which takes precidence over `Swift.Sendable` when it is imported within the file you are trying to mock within.

The fix for this is to add a base type to the `Sendable` inherited type definition, I don't think this will have any adverse side effects for other users where the clash is not an issue but it will allow for cases where `Sendable` is defined elsewhere.