### PR TITLE
feat: add support for SwiftSyntax601

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let doc = Context.environment["MOCKABLE_DOC"].flatMap(Bool.init) ?? false
 func when<T>(_ condition: Bool, _ list: [T]) -> [T] { condition ? list : [] }
 
 let devDependencies: [Package.Dependency] = when(test, [
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", exact: "0.5.2")
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", exact: "0.6.3")
 ]) + when(lint, [
     .package(url: "https://github.com/realm/SwiftLint", exact: "0.57.1"),
 ]) + when(doc, [
@@ -53,7 +53,7 @@ let package = Package(
         )
     ],
     dependencies: devDependencies + [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"601.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"602.0.0"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", .upToNextMajor(from: "1.4.1"))
     ],
     targets: devTargets + [

--- a/Sources/MockableMacro/Extensions/GenericArgumentSyntax+Extensions.swift
+++ b/Sources/MockableMacro/Extensions/GenericArgumentSyntax+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  GenericArgumentSyntax+Extensions.swift
+//  Mockable
+//
+//  Created by Scott Hoyt on 10/06/2025.
+//
+
+import SwiftSyntax
+
+#if canImport(SwiftSyntax601)
+// The purpose of this initializer is to silence deprecation warnings by the using the new API when
+// built against SwiftSyntax >= 601.0.0
+extension GenericArgumentSyntax {
+    init(argument: any TypeSyntaxProtocol) {
+        self.init(argument: Argument(argument))
+    }
+}
+#endif

--- a/Sources/MockableMacro/Requirements/Requirements.swift
+++ b/Sources/MockableMacro/Requirements/Requirements.swift
@@ -137,7 +137,16 @@ extension Requirements {
         } else if let type = type.as(IdentifierTypeSyntax.self),
                   let argumentClause = type.genericArgumentClause {
             return argumentClause.arguments.contains {
+                #if canImport(SwiftSyntax601)
+                switch $0.argument {
+                case .type(let type):
+                    return hasParametrizedProtocolRequirement(type)
+                default:
+                    return false
+                }
+                #else
                 return hasParametrizedProtocolRequirement($0.argument)
+                #endif
             }
         } else {
             return false


### PR DESCRIPTION
By @scottrhoyt in #119:

Fixes #117 

## Motivation

Allow Mockable to build against SwiftSyntax 601.0.1 which is the [first version that takes advantage of the preview of the prebuilts functionality in SPM](https://forums.swift.org/t/preview-swift-syntax-prebuilts-for-macros/80202). This greatly improves compile times for builds that depend on SwiftSyntax for macros.

## Problem

SwiftSyntax 601.0.0 introduced a new nested type in `GenericArgumentSyntax` (`Argument` enum) that encapsulates the Swift parser being able to parse [values as types in certain situations](https://github.com/swiftlang/swift-syntax/pull/2859).

## Proposed Solution

This represents a minimal change set to 1. get Mockable compiling against SwiftSyntax v601 and 2. Silence deprecation warnings.
1. Create overload for `hasParametrizedProtocolRequirement` that accepts the new `Argument` type conditioned on the new SwiftSyntax version to enable compiling.
2. Create a convenience init for `GenericArgumentSyntax` that wraps items of type `TypeSyntaxProtocol` into the new `Argument` type to silence deprecation warnings.

## Results

Package builds and tests pass.

Mockable builds agains SwiftSyntax v601 and enables the new prebuilts functionality. On my computer, this cuts Mockable compile time from 25s debug / 140s release down to 9s.

## Known Issues

* Mockable won't build against SwiftSyntax 601.0.0 because of a missing dependency on the SwiftSyntax601 module. This was [resolved](https://github.com/swiftlang/swift-syntax/pull/3036) in SwiftSyntax 601.0.1.
* `swift test` does not work because of an [issue with SwiftLint and the new Swift toolchain](https://github.com/realm/SwiftLint/issues/6042). This looks like it will [resolve with Swift 6.2](https://github.com/swiftlang/swift-package-manager/pull/8440).
* Cannot run lint against SwiftSyntax 601.0.1 because SwiftLint [only supports  601.0.0](https://github.com/realm/SwiftLint/blob/a3aec89e21f239a274be3c984a473b69789334b7/Package.swift#L36) which is missing the `SwiftSyntax601` marker module.