### PR TITLE
Remove duplicate`nonisolated` keywords and don't add `nonisolated` to typealias

### DIFF
--- a/Sources/Mockable/Mocker/Matchable.swift
+++ b/Sources/Mockable/Mocker/Matchable.swift
@@ -6,7 +6,7 @@
 //
 
 /// A protocol for types that can be used as matchers in mock assertions.
-public protocol Matchable {
+nonisolated public protocol Matchable {
     /// Determines if the receiver matches another instance of the same type according to custom criteria.
     ///
     /// - Parameter other: The instance to compare against.

--- a/Sources/MockableMacro/Extensions/AttributeListSyntax.swift
+++ b/Sources/MockableMacro/Extensions/AttributeListSyntax.swift
@@ -1,0 +1,13 @@
+import SwiftSyntax
+
+extension AttributeListSyntax {
+    func contains(_ name: String) -> Bool {
+        trimmed.contains { element in
+            guard case .attribute(let attribute) = element else {
+                return false
+            }
+
+            return attribute.attributeName.as(IdentifierTypeSyntax.self)?.description == name
+        }
+    }
+}

--- a/Sources/MockableMacro/Extensions/DeclModifierListSyntax+Extensions.swift
+++ b/Sources/MockableMacro/Extensions/DeclModifierListSyntax+Extensions.swift
@@ -15,6 +15,21 @@ extension DeclModifierListSyntax {
         }
     }
 
+    func firstIndex(of keyword: Keyword) -> SyntaxChildrenIndex? {
+        firstIndex { modifier in
+            guard case .keyword(let k) = modifier.name.tokenKind else { return false }
+            return k == keyword
+        }
+    }
+
+    mutating func remove(keyword: Keyword) {
+        guard let index = firstIndex(of: keyword) else {
+            return
+        }
+
+        remove(at: index)
+    }
+
     func appending(_ other: DeclModifierListSyntax) -> DeclModifierListSyntax {
         self + Array(other)
     }

--- a/Sources/MockableMacro/Factory/BuilderFactory.swift
+++ b/Sources/MockableMacro/Factory/BuilderFactory.swift
@@ -62,7 +62,14 @@ extension BuilderFactory {
                 MemberBlockItemSyntax(
                     decl: try function.builder(
                         of: kind,
-                        with: requirements.modifiers,
+                        with: {
+                            var modifiers = requirements.modifiers
+                            if function.syntax.attributes.contains("MainActor") {
+                                modifiers.remove(keyword: .nonisolated)
+                            }
+
+                            return modifiers
+                        }(),
                         using: requirements.syntax.mockType
                     )
                 )

--- a/Sources/MockableMacro/Factory/ConformanceFactory.swift
+++ b/Sources/MockableMacro/Factory/ConformanceFactory.swift
@@ -37,7 +37,16 @@ extension ConformanceFactory {
         try MemberBlockItemListSyntax {
             for function in requirements.functions {
                 MemberBlockItemSyntax(
-                    decl: try function.implement(with: requirements.modifiers)
+                    decl: try function.implement(
+                        with: {
+                            var modifiers = requirements.modifiers
+                            if function.syntax.attributes.contains("MainActor") {
+                                modifiers.remove(keyword: .nonisolated)
+                            }
+
+                            return modifiers
+                        }()
+                    )
                 )
             }
         }

--- a/Sources/MockableMacro/Factory/EnumFactory.swift
+++ b/Sources/MockableMacro/Factory/EnumFactory.swift
@@ -14,7 +14,14 @@ import SwiftSyntax
 enum EnumFactory: Factory {
     static func build(from requirements: Requirements) throws -> EnumDeclSyntax {
         EnumDeclSyntax(
-            modifiers: requirements.modifiers,
+            modifiers: {
+                var modifiers = requirements.modifiers
+                if !modifiers.contains(where: { $0.name.tokenKind == .keyword(.nonisolated) }) {
+                    modifiers.append(DeclModifierSyntax(name: .keyword(.nonisolated)))
+                }
+
+                return modifiers
+            }(),
             name: NS.Member,
             inheritanceClause: inheritanceClause,
             memberBlock: MemberBlockSyntax(members: try members(requirements))

--- a/Sources/MockableMacro/Factory/MemberFactory.swift
+++ b/Sources/MockableMacro/Factory/MemberFactory.swift
@@ -126,12 +126,7 @@ extension MemberFactory {
     }
 
     private static func memberModifiers(_ requirements: Requirements) -> DeclModifierListSyntax {
-        var modifiers = requirements.modifiers
-        if !modifiers.contains(where: { $0.name.tokenKind == .keyword(.nonisolated) }) {
-            modifiers.append(DeclModifierSyntax(name: .keyword(.nonisolated)))
-        }
-
-        return modifiers
+        requirements.modifiers
     }
 
     private static var scopesParameter: FunctionParameterSyntax {

--- a/Sources/MockableMacro/Factory/MemberFactory.swift
+++ b/Sources/MockableMacro/Factory/MemberFactory.swift
@@ -38,7 +38,7 @@ extension MemberFactory {
 
     private static func mockerAlias(_ requirements: Requirements) -> TypeAliasDeclSyntax {
         TypeAliasDeclSyntax(
-            modifiers: requirements.modifiers,
+            modifiers: requirements.modifiers.filter({ $0.name.tokenKind != .keyword(.nonisolated) }),
             name: NS.Mocker,
             initializer: TypeInitializerClauseSyntax(
                 value: MemberTypeSyntax(
@@ -127,7 +127,10 @@ extension MemberFactory {
 
     private static func memberModifiers(_ requirements: Requirements) -> DeclModifierListSyntax {
         var modifiers = requirements.modifiers
-        modifiers.append(DeclModifierSyntax(name: .keyword(.nonisolated)))
+        if !modifiers.contains(where: { $0.name.tokenKind == .keyword(.nonisolated) }) {
+            modifiers.append(DeclModifierSyntax(name: .keyword(.nonisolated)))
+        }
+
         return modifiers
     }
 


### PR DESCRIPTION
We just started using mockable in a project that is using Swift 6.2's MainActor default isolation, where we have marked a protocol explicitly as nonisolated. This resulted in the below errors:

![Screenshot 2025-06-26 at 14 28 31](https://github.com/user-attachments/assets/53a64cf4-b00b-4fb0-b5dd-f66b1238d26b)