### PR TITLE
Fix Swift 6.1 and 6.2 Issues

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 jobs:
-  lint:
+  commit-lint:
     name: Lint Commit Messages
     runs-on: ubuntu-latest
     steps:
@@ -26,57 +26,41 @@ jobs:
       - name: Run commitlint
         run: commitlint -x @commitlint/config-conventional --from=${{ github.event.pull_request.base.sha }} --to=${{ github.event.pull_request.head.sha }}
 
-  test:
-    name: Build and Test using Swift 5.9
-    runs-on: macos-14
-    env:
-      MOCKABLE_TEST: true
+  swift-lint:
+    name: SwiftLint
+    runs-on: macos-latest
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-      - name: Select Xcode 15.2 (Swift 5.9.2)
-        run: |
-          sudo xcode-select -s /Applications/Xcode_15.2.app
-          swift -version
+    - name: Install SwiftLint
+      run: brew install swiftlint
 
-      - name: Run Tests
-        run: |
-          Scripts/test.sh
-
-  test-swift6:
-    name: Build and Test using Swift 6
-    runs-on: macos-14
-    env:
-      MOCKABLE_LINT: true
-      MOCKABLE_TEST: true
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Select Xcode 16 (Swift 6.0)
-        run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app
-          swift --version
-
-      - name: Run Tests
-        run: |
-          Scripts/lint.sh & Scripts/test.sh
-
-  test-linux:
+    - name: Run SwiftLint
+      run: swiftlint lint --strict Sources Tests/MockableTests
+  
+  linux-tests:
     name: Build and Test on Linux
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        swift: ["5", "6"]
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_windows_checks: false
+      linux_env_vars: |
+        MOCKABLE_LINT=false
+        MOCKABLE_TEST=true
+
+  macOS-tests:
+    name: Build and Test on macos-latest
+    runs-on: macos-latest
     env:
+      MOCKABLE_LINT: false
       MOCKABLE_TEST: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: ${{ matrix.swift }}
+      - name: Swift Version
+        run: |
+          swift -version
       - name: Run Tests
         run: |
-          Scripts/test.sh
+          swift build && swift test

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let doc = Context.environment["MOCKABLE_DOC"].flatMap(Bool.init) ?? false
 func when<T>(_ condition: Bool, _ list: [T]) -> [T] { condition ? list : [] }
 
 let devDependencies: [Package.Dependency] = when(test, [
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", exact: "0.6.3")
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", exact: "0.6.4")
 ]) + when(lint, [
     .package(url: "https://github.com/realm/SwiftLint", exact: "0.57.1"),
 ]) + when(doc, [
@@ -54,7 +54,7 @@ let package = Package(
     ],
     dependencies: devDependencies + [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"603.0.0"),
-        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", .upToNextMajor(from: "1.6.1"))
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", .upToNextMajor(from: "1.6.0"))
     ],
     targets: devTargets + [
         .target(
@@ -84,3 +84,4 @@ let package = Package(
     ],
     swiftLanguageVersions: [.v5, .version("6")]
 )
+

--- a/Sources/MockableMacro/Extensions/AttributeListSyntax+Extensions.swift
+++ b/Sources/MockableMacro/Extensions/AttributeListSyntax+Extensions.swift
@@ -1,0 +1,33 @@
+//
+//  File.swift
+//  Mockable
+//
+//  Created by Kolos Foltányi on 2025. 11. 16..
+//
+
+import SwiftSyntax
+
+extension AttributeListSyntax {
+    func filter(allowedNames: [String]) -> AttributeListSyntax {
+        filter { element in
+            switch element {
+            case .attribute(let attributeSyntax):
+                return attribute(attributeSyntax, matches: allowedNames)
+            case .ifConfigDecl(let ifConfigDeclSyntax):
+                return ifConfigDeclSyntax.clauses
+                    .compactMap { $0.elements }
+                    .allSatisfy { item in
+                        guard case .attributes(let list) = item else { return false }
+                        return list.allSatisfy {
+                            guard case .attribute(let attr) = $0 else { return false }
+                            return attribute(attr, matches: allowedNames)
+                        }
+                    }
+            }
+        }
+    }
+
+    private func attribute(_ attribute: AttributeSyntax, matches allowedNames: [String]) -> Bool {
+        allowedNames.contains(attribute.attributeName.trimmedDescription)
+    }
+}

--- a/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
@@ -16,8 +16,13 @@ extension FunctionRequirement: Buildable {
         using mockType: IdentifierTypeSyntax
     ) throws -> DeclSyntax {
         let decl = FunctionDeclSyntax(
-            attributes: syntax.attributes.trimmed.with(\.trailingTrivia, .newline),
-            modifiers: modifiers,
+            attributes: syntax.attributes
+                .filter(allowedNames: [NS.available.text])
+                .trimmed.with(\.trailingTrivia, .newline),
+            modifiers: DeclModifierListSyntax {
+                modifiers
+                DeclModifierSyntax(name: .keyword(.nonisolated))
+            },
             name: syntax.name.trimmed,
             genericParameterClause: genericParameterClause(for: kind),
             signature: signature(for: kind, using: mockType),

--- a/Sources/MockableMacro/Factory/Buildable/Variable+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Variable+Buildable.swift
@@ -32,8 +32,13 @@ extension VariableRequirement {
         using mockType: IdentifierTypeSyntax
     ) throws -> DeclSyntax {
         let variableDecl = VariableDeclSyntax(
-            attributes: syntax.attributes.trimmed.with(\.trailingTrivia, .newline),
-            modifiers: modifiers,
+            attributes: syntax.attributes
+                .filter(allowedNames: [NS.available.text])
+                .trimmed.with(\.trailingTrivia, .newline),
+            modifiers: DeclModifierListSyntax {
+                modifiers
+                DeclModifierSyntax(name: .keyword(.nonisolated))
+            },
             bindingSpecifier: .keyword(.var),
             bindings: try PatternBindingListSyntax {
                 PatternBindingSyntax(

--- a/Sources/MockableMacro/Factory/BuilderFactory.swift
+++ b/Sources/MockableMacro/Factory/BuilderFactory.swift
@@ -88,7 +88,10 @@ extension BuilderFactory {
         _ requirements: Requirements
     ) -> InitializerDeclSyntax {
         InitializerDeclSyntax(
-            modifiers: requirements.modifiers,
+            modifiers: DeclModifierListSyntax {
+                requirements.modifiers
+                DeclModifierSyntax(name: .keyword(.nonisolated))
+            },
             signature: initializerSignature(kind, requirements)
         ) {
             InfixOperatorExprSyntax(

--- a/Sources/MockableMacro/Factory/MemberFactory.swift
+++ b/Sources/MockableMacro/Factory/MemberFactory.swift
@@ -126,9 +126,10 @@ extension MemberFactory {
     }
 
     private static func memberModifiers(_ requirements: Requirements) -> DeclModifierListSyntax {
-        var modifiers = requirements.modifiers
-        modifiers.append(DeclModifierSyntax(name: .keyword(.nonisolated)))
-        return modifiers
+        DeclModifierListSyntax {
+            requirements.modifiers
+            DeclModifierSyntax(name: .keyword(.nonisolated))
+        }
     }
 
     private static var scopesParameter: FunctionParameterSyntax {

--- a/Sources/MockableMacro/Requirements/Requirements.swift
+++ b/Sources/MockableMacro/Requirements/Requirements.swift
@@ -50,7 +50,7 @@ extension Requirements {
             guard case .keyword(let keyword) = modifier.name.tokenKind else {
                 return true
             }
-            return keyword != .private
+            return keyword != .private && keyword != .nonisolated
         }
     }
 

--- a/Sources/MockableMacro/Utils/Namespace.swift
+++ b/Sources/MockableMacro/Utils/Namespace.swift
@@ -43,6 +43,7 @@ enum NS {
     static let performActions: TokenSyntax = "performActions"
     static let policy: TokenSyntax = "policy"
     static let error: TokenSyntax = "error"
+    static let swift: TokenSyntax = "swift"
     static let iOS: TokenSyntax = "iOS"
     static let macOS: TokenSyntax = "macOS"
     static let tvOS: TokenSyntax = "tvOS"
@@ -55,6 +56,7 @@ enum NS {
     static let _init: TokenSyntax = "init"
     static let _star: TokenSyntax = "*"
     static let _for: TokenSyntax = "for"
+    static let _gte: String = ">="
     static let get_: String = "get_"
     static let set_: String = "set_"
 

--- a/Sources/MockableMacro/Utils/SwiftVersionHelper.swift
+++ b/Sources/MockableMacro/Utils/SwiftVersionHelper.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//  Mockable
+//
+//  Created by Kolos Foltányi on 2025. 11. 13..
+//
+
+import SwiftSyntax
+
+enum SwiftVersionRequirement: TokenSyntax {
+    case swift_6_1 = "6.1"
+}
+
+enum SwiftVersionHelper {
+    static func condition(
+        minimumVersion: SwiftVersionRequirement,
+        gte latest: IfConfigClauseSyntax.Elements,
+        else fallback: IfConfigClauseSyntax.Elements
+    ) -> IfConfigDeclSyntax {
+        IfConfigDeclSyntax(
+            clauses: IfConfigClauseListSyntax {
+                IfConfigClauseSyntax(
+                    poundKeyword: .poundIfToken(),
+                    condition: FunctionCallExprSyntax(
+                        calledExpression: DeclReferenceExprSyntax(baseName: NS.swift),
+                        leftParen: .leftParenToken(),
+                        arguments: LabeledExprListSyntax {
+                            LabeledExprSyntax(
+                                expression: PrefixOperatorExprSyntax(
+                                    operator: .prefixOperator(NS._gte),
+                                    expression: FloatLiteralExprSyntax(literal: minimumVersion.rawValue)
+                                )
+                            )
+                        },
+                        rightParen: .rightParenToken(),
+                        additionalTrailingClosures: MultipleTrailingClosureElementListSyntax()
+                    ),
+                    elements: latest
+                )
+                IfConfigClauseSyntax(
+                    poundKeyword: .poundElseToken(),
+                    elements: fallback
+                )
+            },
+            poundEndif: .poundEndifToken()
+        )
+    }
+}

--- a/Tests/MockableMacroTests/AccessModifierTests.swift
+++ b/Tests/MockableMacroTests/AccessModifierTests.swift
@@ -69,10 +69,11 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                public nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
-                    public func match(_ other: Member) -> Bool {
+                    public nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
@@ -83,39 +84,55 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    case m2_bar(number: Parameter<Int>)
+                    public nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        case (.m2_bar(number: let leftNumber), .m2_bar(number: let rightNumber)):
+                            return leftNumber.match(rightNumber)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 public struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    public init(mocker: Mocker) {
+                    public nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    public nonisolated var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    public func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    public nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
                 public struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    public init(mocker: Mocker) {
+                    public nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    public nonisolated var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    public func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    public nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
                 public struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    public init(mocker: Mocker) {
+                    public nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    public nonisolated var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    public func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    public nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
@@ -181,10 +198,11 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_bar(number: Parameter<Int>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
@@ -195,39 +213,55 @@ final class AccessModifierTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    case m2_bar(number: Parameter<Int>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        case (.m2_bar(number: let leftNumber), .m2_bar(number: let rightNumber)):
+                            return leftNumber.match(rightNumber)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_bar(number: number))
                     }
                 }
@@ -282,39 +316,51 @@ final class AccessModifierTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                public nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
-                    public func match(_ other: Member) -> Bool {
+                    public nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
                         }
                     }
                 }
+                #else
+                public enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    public nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #endif
                 public struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    public init(mocker: Mocker) {
+                    public nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
+                    public nonisolated func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 public struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    public init(mocker: Mocker) {
+                    public nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    public nonisolated func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 public struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    public init(mocker: Mocker) {
+                    public nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    public func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    public nonisolated func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }

--- a/Tests/MockableMacroTests/ActorConformanceTests.swift
+++ b/Tests/MockableMacroTests/ActorConformanceTests.swift
@@ -87,12 +87,13 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_quz
                     case m3_bar(number: Parameter<Int>)
                     case m4_baz(number: Parameter<Int>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
@@ -107,57 +108,79 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    case m2_quz
+                    case m3_bar(number: Parameter<Int>)
+                    case m4_baz(number: Parameter<Int>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        case (.m2_quz, .m2_quz):
+                            return true
+                        case (.m3_bar(number: let leftNumber), .m3_bar(number: let rightNumber)):
+                            return leftNumber.match(rightNumber)
+                        case (.m4_baz(number: let leftNumber), .m4_baz(number: let rightNumber)):
+                            return leftNumber.match(rightNumber)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var quz: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    nonisolated func baz(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m4_baz(number: number))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var quz: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func baz(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m4_baz(number: number))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var quz: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func baz(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m4_baz(number: number))
                     }
                 }
@@ -242,12 +265,13 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
                     case m2_quz
                     case m3_bar(number: Parameter<Int>)
                     case m4_baz(number: Parameter<Int>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
@@ -262,58 +286,279 @@ final class ActorConformanceTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    case m2_quz
+                    case m3_bar(number: Parameter<Int>)
+                    case m4_baz(number: Parameter<Int>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        case (.m2_quz, .m2_quz):
+                            return true
+                        case (.m3_bar(number: let leftNumber), .m3_bar(number: let rightNumber)):
+                            return leftNumber.match(rightNumber)
+                        case (.m4_baz(number: let leftNumber), .m4_baz(number: let rightNumber)):
+                            return leftNumber.match(rightNumber)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var quz: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
+                    nonisolated func baz(number: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, (Int) -> Int> {
                         .init(mocker, kind: .m4_baz(number: number))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var quz: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func baz(number: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m4_baz(number: number))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
-                    var quz: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var quz: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_quz)
                     }
-                    func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func bar(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_bar(number: number))
                     }
-                    func baz(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func baz(number: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m4_baz(number: number))
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    func test_nonisolated_protocol() {
+        assertMacro {
+          """
+          @Mockable
+          nonisolated protocol Test {
+              func foo()
+          }
+          """
+        } expansion: {
+            """
+            nonisolated protocol Test {
+                func foo()
+            }
+
+            #if MOCKING
+            nonisolated final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
+                @available(*, deprecated, message: "Use given(_ service:) instead. ")
+                nonisolated var _given: ReturnBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use when(_ service:) instead. ")
+                nonisolated var _when: ActionBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use verify(_ service:) instead. ")
+                nonisolated var _verify: VerifyBuilder {
+                    .init(mocker: mocker)
+                }
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                    mocker.reset(scopes: scopes)
+                }
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
+                }
+                func foo() {
+                    let member: Member = .m1_foo
+                    mocker.mock(member) { producer in
+                        let producer = try cast(producer) as () -> Void
+                        return producer()
+                    }
+                }
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #endif
+                struct ReturnBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    nonisolated init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    nonisolated func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
+                        .init(mocker, kind: .m1_foo)
+                    }
+                }
+                struct ActionBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    nonisolated init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    nonisolated func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                        .init(mocker, kind: .m1_foo)
+                    }
+                }
+                struct VerifyBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    nonisolated init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    nonisolated func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                        .init(mocker, kind: .m1_foo)
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    func test_mainactor_requirement() {
+        assertMacro {
+          """
+          @Mockable
+          protocol Test {
+              @MainActor func foo()
+          }
+          """
+        } expansion: {
+            """
+            protocol Test {
+                @MainActor func foo()
+            }
+
+            #if MOCKING
+            final class MockTest: Test, Mockable.MockableService {
+                typealias Mocker = Mockable.Mocker<MockTest>
+                private let mocker = Mocker()
+                @available(*, deprecated, message: "Use given(_ service:) instead. ")
+                nonisolated var _given: ReturnBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use when(_ service:) instead. ")
+                nonisolated var _when: ActionBuilder {
+                    .init(mocker: mocker)
+                }
+                @available(*, deprecated, message: "Use verify(_ service:) instead. ")
+                nonisolated var _verify: VerifyBuilder {
+                    .init(mocker: mocker)
+                }
+                nonisolated func reset(_ scopes: Set<Mockable.MockerScope> = .all) {
+                    mocker.reset(scopes: scopes)
+                }
+                nonisolated init(policy: Mockable.MockerPolicy? = nil) {
+                    if let policy {
+                        mocker.policy = policy
+                    }
+                }
+                @MainActor
+                func foo() {
+                    let member: Member = .m1_foo
+                    mocker.mock(member) { producer in
+                        let producer = try cast(producer) as () -> Void
+                        return producer()
+                    }
+                }
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #endif
+                struct ReturnBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    nonisolated init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    nonisolated func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
+                        .init(mocker, kind: .m1_foo)
+                    }
+                }
+                struct ActionBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    nonisolated init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    nonisolated func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                        .init(mocker, kind: .m1_foo)
+                    }
+                }
+                struct VerifyBuilder: Mockable.Builder {
+                    private let mocker: Mocker
+                    nonisolated init(mocker: Mocker) {
+                        self.mocker = mocker
+                    }
+                    nonisolated func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                        .init(mocker, kind: .m1_foo)
                     }
                 }
             }

--- a/Tests/MockableMacroTests/AssociatedTypeTests.swift
+++ b/Tests/MockableMacroTests/AssociatedTypeTests.swift
@@ -56,39 +56,51 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<Item>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
                             return leftItem.match(rightItem)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo(item: Parameter<Item>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
+                            return leftItem.match(rightItem)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
@@ -145,39 +157,51 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<Item>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
                             return leftItem.match(rightItem)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo(item: Parameter<Item>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
+                            return leftItem.match(rightItem)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
@@ -234,39 +258,51 @@ final class AssociatedTypeTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<Item>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
                             return leftItem.match(rightItem)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo(item: Parameter<Item>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
+                            return leftItem.match(rightItem)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Item, (Item) -> Item> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func foo(item: Parameter<Item>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item))
                     }
                 }

--- a/Tests/MockableMacroTests/AttributesTests.swift
+++ b/Tests/MockableMacroTests/AttributesTests.swift
@@ -115,12 +115,13 @@ final class AttributesTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_prop
                     case m2_prop2
                     case m3_test
                     case m4_test2
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_prop, .m1_prop):
                             return true
@@ -135,69 +136,91 @@ final class AttributesTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_prop
+                    case m2_prop2
+                    case m3_test
+                    case m4_test2
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_prop, .m1_prop):
+                            return true
+                        case (.m2_prop2, .m2_prop2):
+                            return true
+                        case (.m3_test, .m3_test):
+                            return true
+                        case (.m4_test2, .m4_test2):
+                            return true
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     @available(iOS 15, *)
-                    var prop: Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var prop: Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_prop)
                     }
                     @available(iOS 15, *)
-                    var prop2: Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var prop2: Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m2_prop2)
                     }
                     @available(iOS 15, *)
-                    func test() -> Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
+                    nonisolated func test() -> Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m3_test)
                     }
                     @available(iOS 15, *)
-                    func test2() -> Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
+                    nonisolated func test2() -> Mockable.FunctionReturnBuilder<MockAttributeTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m4_test2)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     @available(iOS 15, *)
-                    var prop: Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    nonisolated var prop: Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                     @available(iOS 15, *)
-                    var prop2: Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    nonisolated var prop2: Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m2_prop2)
                     }
                     @available(iOS 15, *)
-                    func test() -> Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    nonisolated func test() -> Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m3_test)
                     }
                     @available(iOS 15, *)
-                    func test2() -> Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
+                    nonisolated func test2() -> Mockable.FunctionActionBuilder<MockAttributeTest, ActionBuilder> {
                         .init(mocker, kind: .m4_test2)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     @available(iOS 15, *)
-                    var prop: Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    nonisolated var prop: Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                     @available(iOS 15, *)
-                    var prop2: Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    nonisolated var prop2: Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_prop2)
                     }
                     @available(iOS 15, *)
-                    func test() -> Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    nonisolated func test() -> Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_test)
                     }
                     @available(iOS 15, *)
-                    func test2() -> Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
+                    nonisolated func test2() -> Mockable.FunctionVerifyBuilder<MockAttributeTest, VerifyBuilder> {
                         .init(mocker, kind: .m4_test2)
                     }
                 }

--- a/Tests/MockableMacroTests/DocCommentsTests.swift
+++ b/Tests/MockableMacroTests/DocCommentsTests.swift
@@ -62,39 +62,51 @@ final class DocCommentsTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var foo: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var foo: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var foo: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }

--- a/Tests/MockableMacroTests/ExoticParameterTests.swift
+++ b/Tests/MockableMacroTests/ExoticParameterTests.swift
@@ -54,39 +54,51 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(&value)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_modifyValue(Parameter<Int>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_modifyValue(let leftParam1), .m1_modifyValue(let rightParam1)):
                             return leftParam1.match(rightParam1)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_modifyValue(Parameter<Int>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_modifyValue(let leftParam1), .m1_modifyValue(let rightParam1)):
+                            return leftParam1.match(rightParam1)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (inout Int) -> Void> {
+                    nonisolated func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (inout Int) -> Void> {
                         .init(mocker, kind: .m1_modifyValue(value))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_modifyValue(value))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func modifyValue(_ value: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_modifyValue(value))
                     }
                 }
@@ -141,39 +153,51 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(values)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_printValues(Parameter<[Int]>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_printValues(let leftParam1), .m1_printValues(let rightParam1)):
                             return leftParam1.match(rightParam1)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_printValues(Parameter<[Int]>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_printValues(let leftParam1), .m1_printValues(let rightParam1)):
+                            return leftParam1.match(rightParam1)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ([Int]) -> Void> {
+                    nonisolated func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ([Int]) -> Void> {
                         .init(mocker, kind: .m1_printValues(values))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_printValues(values))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func printValues(_ values: Parameter<[Int]>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_printValues(values))
                     }
                 }
@@ -228,39 +252,51 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_execute(operation: let leftOperation), .m1_execute(operation: let rightOperation)):
                             return leftOperation.match(rightOperation)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_execute(operation: Parameter<() throws -> Void>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_execute(operation: let leftOperation), .m1_execute(operation: let rightOperation)):
+                            return leftOperation.match(rightOperation)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
+                    nonisolated func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
@@ -315,39 +351,51 @@ final class ExoticParameterTests: MockableMacroTestCase {
                         return producer(`for`)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(for: Parameter<String>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo(for: let leftFor), .m1_foo(for: let rightFor)):
                             return leftFor.match(rightFor)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo(for: Parameter<String>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo(for: let leftFor), .m1_foo(for: let rightFor)):
+                            return leftFor.match(rightFor)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(for: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (String) -> Void> {
+                    nonisolated func foo(for: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (String) -> Void> {
                         .init(mocker, kind: .m1_foo(for: `for`))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(for: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func foo(for: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(for: `for`))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo(for: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func foo(for: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(for: `for`))
                     }
                 }

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -63,10 +63,11 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_returnsAndThrows
                     case m2_canThrowError
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_returnsAndThrows, .m1_returnsAndThrows):
                             return true
@@ -77,39 +78,55 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_returnsAndThrows
+                    case m2_canThrowError
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_returnsAndThrows, .m1_returnsAndThrows):
+                            return true
+                        case (.m2_canThrowError, .m2_canThrowError):
+                            return true
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func returnsAndThrows() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, any Error, () throws -> String> {
+                    nonisolated func returnsAndThrows() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, any Error, () throws -> String> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    func canThrowError() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, () throws -> Void> {
+                    nonisolated func canThrowError() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, () throws -> Void> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func returnsAndThrows() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func returnsAndThrows() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    func canThrowError() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func canThrowError() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func returnsAndThrows() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func returnsAndThrows() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    func canThrowError() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func canThrowError() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
@@ -164,39 +181,51 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return producer(operation)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_execute(operation: Parameter<() throws -> Void>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_execute(operation: let leftOperation), .m1_execute(operation: let rightOperation)):
                             return leftOperation.match(rightOperation)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_execute(operation: Parameter<() throws -> Void>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_execute(operation: let leftOperation), .m1_execute(operation: let rightOperation)):
+                            return leftOperation.match(rightOperation)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
+                    nonisolated func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (@escaping () throws -> Void) -> Void> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func execute(operation: Parameter<() throws -> Void>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_execute(operation: operation))
                     }
                 }
@@ -269,11 +298,12 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         return try producer(param)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_asyncFunction
                     case m2_asyncThrowingFunction
                     case m3_asyncParamFunction(param: Parameter<() async throws -> Void>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_asyncFunction, .m1_asyncFunction):
                             return true
@@ -286,48 +316,67 @@ final class FunctionEffectTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_asyncFunction
+                    case m2_asyncThrowingFunction
+                    case m3_asyncParamFunction(param: Parameter<() async throws -> Void>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_asyncFunction, .m1_asyncFunction):
+                            return true
+                        case (.m2_asyncThrowingFunction, .m2_asyncThrowingFunction):
+                            return true
+                        case (.m3_asyncParamFunction(param: let leftParam), .m3_asyncParamFunction(param: let rightParam)):
+                            return leftParam.match(rightParam)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func asyncFunction() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
+                    nonisolated func asyncFunction() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, () throws -> Void> {
+                    nonisolated func asyncThrowingFunction() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, () throws -> Void> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, (@escaping () async throws -> Void) throws -> Void> {
+                    nonisolated func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, (@escaping () async throws -> Void) throws -> Void> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func asyncFunction() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func asyncFunction() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func asyncThrowingFunction() -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func asyncFunction() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func asyncFunction() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    func asyncThrowingFunction() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func asyncThrowingFunction() -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }

--- a/Tests/MockableMacroTests/GenericFunctionTests.swift
+++ b/Tests/MockableMacroTests/GenericFunctionTests.swift
@@ -54,39 +54,51 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo(item: Parameter<GenericValue>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
                             return leftItem.match(rightItem)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo(item: Parameter<GenericValue>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo(item: let leftItem), .m1_foo(item: let rightItem)):
+                            return leftItem.match(rightItem)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ((Array<[(Set<T>, String)]>, Int)) -> Void> {
+                    nonisolated func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, ((Array<[(Set<T>, String)]>, Int)) -> Void> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func foo<T>(item: Parameter<(Array<[(Set<T>, String)]>, Int)>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo(item: item.eraseToGenericValue()))
                     }
                 }
@@ -141,39 +153,51 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(item)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_genericFunc(item: Parameter<GenericValue>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_genericFunc(item: let leftItem), .m1_genericFunc(item: let rightItem)):
                             return leftItem.match(rightItem)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_genericFunc(item: Parameter<GenericValue>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_genericFunc(item: let leftItem), .m1_genericFunc(item: let rightItem)):
+                            return leftItem.match(rightItem)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func genericFunc<T, V>(item: Parameter<T>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, V, (T) -> V> {
+                    nonisolated func genericFunc<T, V>(item: Parameter<T>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, V, (T) -> V> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func genericFunc<T>(item: Parameter<T>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func genericFunc<T>(item: Parameter<T>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func genericFunc<T>(item: Parameter<T>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func genericFunc<T>(item: Parameter<T>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_genericFunc(item: item.eraseToGenericValue()))
                     }
                 }
@@ -235,21 +259,33 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer(p1, p2, p3, p4)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_method1(p1: Parameter<GenericValue>, p2: Parameter<GenericValue>, p3: Parameter<GenericValue>, p4: Parameter<GenericValue>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_method1(p1: let leftP1, p2: let leftP2, p3: let leftP3, p4: let leftP4), .m1_method1(p1: let rightP1, p2: let rightP2, p3: let rightP3, p4: let rightP4)):
                             return leftP1.match(rightP1) && leftP2.match(rightP2) && leftP3.match(rightP3) && leftP4.match(rightP4)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_method1(p1: Parameter<GenericValue>, p2: Parameter<GenericValue>, p3: Parameter<GenericValue>, p4: Parameter<GenericValue>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_method1(p1: let leftP1, p2: let leftP2, p3: let leftP3, p4: let leftP4), .m1_method1(p1: let rightP1, p2: let rightP2, p3: let rightP3, p4: let rightP4)):
+                            return leftP1.match(rightP1) && leftP2.match(rightP2) && leftP3.match(rightP3) && leftP4.match(rightP4)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func method1<T: Hashable, E, C, I>(
+                    nonisolated func method1<T: Hashable, E, C, I>(
                             p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, (T, E, C, I) -> Void> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()))
@@ -257,10 +293,10 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func method1<T: Hashable, E, C, I>(
+                    nonisolated func method1<T: Hashable, E, C, I>(
                             p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()))
@@ -268,10 +304,10 @@ final class GenericFunctionTests: MockableMacroTestCase {
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func method1<T: Hashable, E, C, I>(
+                    nonisolated func method1<T: Hashable, E, C, I>(
                             p1: Parameter<T>, p2: Parameter<E>, p3: Parameter<C>, p4: Parameter<I>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> where E: Equatable, E: Hashable, C: Codable {
                         .init(mocker, kind: .m1_method1(p1:
                                 p1.eraseToGenericValue(), p2: p2.eraseToGenericValue(), p3: p3.eraseToGenericValue(), p4: p4.eraseToGenericValue()))
@@ -331,39 +367,51 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_prop
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_prop, .m1_prop):
                             return true
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_prop
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_prop, .m1_prop):
+                            return true
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<String>, () -> any SomeProtocol<String>> {
+                    nonisolated var prop: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<String>, () -> any SomeProtocol<String>> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var prop: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var prop: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
@@ -421,39 +469,51 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_prop
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_prop, .m1_prop):
                             return true
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_prop
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_prop, .m1_prop):
+                            return true
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
+                    nonisolated var prop: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var prop: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var prop: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var prop: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_prop)
                     }
                 }
@@ -509,39 +569,51 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<Double>, () -> any SomeProtocol<Double>> {
+                    nonisolated func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, any SomeProtocol<Double>, () -> any SomeProtocol<Double>> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
@@ -597,39 +669,51 @@ final class GenericFunctionTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
+                    nonisolated func foo() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Parent<String, Child<any SomeProtocol<Double>>>, () -> Parent<String, Child<any SomeProtocol<Double>>>> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func foo() -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func foo() -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }

--- a/Tests/MockableMacroTests/InheritedTypeMappingTests.swift
+++ b/Tests/MockableMacroTests/InheritedTypeMappingTests.swift
@@ -54,39 +54,51 @@ final class InheritedTypeMappingTests: MockableMacroTestCase {
                         return producer()
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_foo
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_foo, .m1_foo):
                             return true
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_foo, .m1_foo):
+                            return true
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionReturnBuilder<MockTestObject, ReturnBuilder, Void, () -> Void> {
+                    nonisolated func foo() -> Mockable.FunctionReturnBuilder<MockTestObject, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionActionBuilder<MockTestObject, ActionBuilder> {
+                    nonisolated func foo() -> Mockable.FunctionActionBuilder<MockTestObject, ActionBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func foo() -> Mockable.FunctionVerifyBuilder<MockTestObject, VerifyBuilder> {
+                    nonisolated func foo() -> Mockable.FunctionVerifyBuilder<MockTestObject, VerifyBuilder> {
                         .init(mocker, kind: .m1_foo)
                     }
                 }

--- a/Tests/MockableMacroTests/InitRequirementTests.swift
+++ b/Tests/MockableMacroTests/InitRequirementTests.swift
@@ -53,27 +53,36 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name: String) {
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
-                    func match(_ other: Member) -> Bool {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
@@ -131,27 +140,36 @@ final class InitRequirementTests: MockableMacroTestCase {
                 }
                 init(name value: String, _ index: Int) {
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
-                    func match(_ other: Member) -> Bool {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                 }

--- a/Tests/MockableMacroTests/NameCollisionTests.swift
+++ b/Tests/MockableMacroTests/NameCollisionTests.swift
@@ -63,10 +63,11 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_fetchData(for: Parameter<Int>)
                     case m2_fetchData(for: Parameter<String>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_fetchData(for: let leftFor), .m1_fetchData(for: let rightFor)):
                             return leftFor.match(rightFor)
@@ -77,39 +78,55 @@ final class NameCollisionTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_fetchData(for: Parameter<Int>)
+                    case m2_fetchData(for: Parameter<String>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_fetchData(for: let leftFor), .m1_fetchData(for: let rightFor)):
+                            return leftFor.match(rightFor)
+                        case (.m2_fetchData(for: let leftFor), .m2_fetchData(for: let rightFor)):
+                            return leftFor.match(rightFor)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(for name: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Int) -> String> {
+                    nonisolated func fetchData(for name: Parameter<Int>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Int) -> String> {
                         .init(mocker, kind: .m1_fetchData(for: name))
                     }
-                    func fetchData(for name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
+                    nonisolated func fetchData(for name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
                         .init(mocker, kind: .m2_fetchData(for: name))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(for name: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func fetchData(for name: Parameter<Int>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_fetchData(for: name))
                     }
-                    func fetchData(for name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func fetchData(for name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_fetchData(for: name))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(for name: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func fetchData(for name: Parameter<Int>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_fetchData(for: name))
                     }
-                    func fetchData(for name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func fetchData(for name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_fetchData(for: name))
                     }
                 }
@@ -173,10 +190,11 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(name)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_fetchData(forA: Parameter<String>)
                     case m2_fetchData(forB: Parameter<String>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_fetchData(forA: let leftForA), .m1_fetchData(forA: let rightForA)):
                             return leftForA.match(rightForA)
@@ -187,39 +205,55 @@ final class NameCollisionTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_fetchData(forA: Parameter<String>)
+                    case m2_fetchData(forB: Parameter<String>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_fetchData(forA: let leftForA), .m1_fetchData(forA: let rightForA)):
+                            return leftForA.match(rightForA)
+                        case (.m2_fetchData(forB: let leftForB), .m2_fetchData(forB: let rightForB)):
+                            return leftForB.match(rightForB)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(forA name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
+                    nonisolated func fetchData(forA name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
                         .init(mocker, kind: .m1_fetchData(forA: name))
                     }
-                    func fetchData(forB name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
+                    nonisolated func fetchData(forB name: Parameter<String>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (String) -> String> {
                         .init(mocker, kind: .m2_fetchData(forB: name))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(forA name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func fetchData(forA name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_fetchData(forA: name))
                     }
-                    func fetchData(forB name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func fetchData(forB name: Parameter<String>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_fetchData(forB: name))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func fetchData(forA name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func fetchData(forA name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_fetchData(forA: name))
                     }
-                    func fetchData(forB name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func fetchData(forB name: Parameter<String>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_fetchData(forB: name))
                     }
                 }
@@ -274,39 +308,51 @@ final class NameCollisionTests: MockableMacroTestCase {
                         return producer(param)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_repeat(param: Parameter<Bool>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_repeat(param: let leftParam), .m1_repeat(param: let rightParam)):
                             return leftParam.match(rightParam)
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_repeat(param: Parameter<Bool>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_repeat(param: let leftParam), .m1_repeat(param: let rightParam)):
+                            return leftParam.match(rightParam)
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Bool) -> String> {
+                    nonisolated func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, (Bool) -> String> {
                         .init(mocker, kind: .m1_repeat(param: param))
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_repeat(param: param))
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated func `repeat`(param: Parameter<Bool>) -> Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_repeat(param: param))
                     }
                 }

--- a/Tests/MockableMacroTests/PropertyRequirementTests.swift
+++ b/Tests/MockableMacroTests/PropertyRequirementTests.swift
@@ -67,10 +67,11 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_computedInt
                     case m2_computedString
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_computedInt, .m1_computedInt):
                             return true
@@ -81,39 +82,55 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_computedInt
+                    case m2_computedString
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_computedInt, .m1_computedInt):
+                            return true
+                        case (.m2_computedString, .m2_computedString):
+                            return true
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var computedInt: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
+                    nonisolated var computedInt: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Int, () -> Int> {
                         .init(mocker, kind: .m1_computedInt)
                     }
-                    var computedString: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
+                    nonisolated var computedString: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
                         .init(mocker, kind: .m2_computedString)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var computedInt: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var computedInt: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_computedInt)
                     }
-                    var computedString: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var computedString: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_computedString)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var computedInt: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var computedInt: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_computedInt)
                     }
-                    var computedString: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var computedString: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_computedString)
                     }
                 }
@@ -191,12 +208,13 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         mocker.performActions(for: member)
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_get_mutableInt
                     case m1_set_mutableInt(newValue: Parameter<Int>)
                     case m2_get_mutableString
                     case m2_set_mutableString(newValue: Parameter<String>)
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_get_mutableInt, .m1_get_mutableInt):
                             return true
@@ -211,21 +229,43 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_get_mutableInt
+                    case m1_set_mutableInt(newValue: Parameter<Int>)
+                    case m2_get_mutableString
+                    case m2_set_mutableString(newValue: Parameter<String>)
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_get_mutableInt, .m1_get_mutableInt):
+                            return true
+                        case (.m1_set_mutableInt(newValue: let leftNewValue), .m1_set_mutableInt(newValue: let rightNewValue)):
+                            return leftNewValue.match(rightNewValue)
+                        case (.m2_get_mutableString, .m2_get_mutableString):
+                            return true
+                        case (.m2_set_mutableString(newValue: let leftNewValue), .m2_set_mutableString(newValue: let rightNewValue)):
+                            return leftNewValue.match(rightNewValue)
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var mutableInt: Mockable.PropertyReturnBuilder<MockTest, ReturnBuilder, Int> {
+                    nonisolated var mutableInt: Mockable.PropertyReturnBuilder<MockTest, ReturnBuilder, Int> {
                         .init(mocker, kind: .m1_get_mutableInt)
                     }
-                    var mutableString: Mockable.PropertyReturnBuilder<MockTest, ReturnBuilder, String> {
+                    nonisolated var mutableString: Mockable.PropertyReturnBuilder<MockTest, ReturnBuilder, String> {
                         .init(mocker, kind: .m2_get_mutableString)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     func mutableInt(newValue: Parameter<Int> = .any) -> Mockable.PropertyActionBuilder<MockTest, ActionBuilder> {
@@ -237,7 +277,7 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
                     func mutableInt(newValue: Parameter<Int> = .any) -> Mockable.PropertyVerifyBuilder<MockTest, VerifyBuilder> {
@@ -322,11 +362,12 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_throwingProperty
                     case m2_asyncProperty
                     case m3_asyncThrowingProperty
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_throwingProperty, .m1_throwingProperty):
                             return true
@@ -339,48 +380,67 @@ final class PropertyRequirementTests: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_throwingProperty
+                    case m2_asyncProperty
+                    case m3_asyncThrowingProperty
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_throwingProperty, .m1_throwingProperty):
+                            return true
+                        case (.m2_asyncProperty, .m2_asyncProperty):
+                            return true
+                        case (.m3_asyncThrowingProperty, .m3_asyncThrowingProperty):
+                            return true
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var throwingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Int, any Error, () throws -> Int> {
+                    nonisolated var throwingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Int, any Error, () throws -> Int> {
                         .init(mocker, kind: .m1_throwingProperty)
                     }
-                    var asyncProperty: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
+                    nonisolated var asyncProperty: Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, String, () -> String> {
                         .init(mocker, kind: .m2_asyncProperty)
                     }
-                    var asyncThrowingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, any Error, () throws -> String> {
+                    nonisolated var asyncThrowingProperty: Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, any Error, () throws -> String> {
                         .init(mocker, kind: .m3_asyncThrowingProperty)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var throwingProperty: Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var throwingProperty: Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m1_throwingProperty)
                     }
-                    var asyncProperty: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var asyncProperty: Mockable.FunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m2_asyncProperty)
                     }
-                    var asyncThrowingProperty: Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
+                    nonisolated var asyncThrowingProperty: Mockable.ThrowingFunctionActionBuilder<MockTest, ActionBuilder> {
                         .init(mocker, kind: .m3_asyncThrowingProperty)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var throwingProperty: Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var throwingProperty: Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m1_throwingProperty)
                     }
-                    var asyncProperty: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var asyncProperty: Mockable.FunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m2_asyncProperty)
                     }
-                    var asyncThrowingProperty: Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
+                    nonisolated var asyncThrowingProperty: Mockable.ThrowingFunctionVerifyBuilder<MockTest, VerifyBuilder> {
                         .init(mocker, kind: .m3_asyncThrowingProperty)
                     }
                 }

--- a/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
+++ b/Tests/MockableMacroTests/TypedThrowsTests_Swift6.swift
@@ -67,10 +67,11 @@ final class TypedThrowsTests_Swift6: MockableMacroTestCase {
                         }
                     }
                 }
-                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                #if swift(>=6.1)
+                nonisolated enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
                     case m1_baz
                     case m2_foo
-                    func match(_ other: Member) -> Bool {
+                    nonisolated func match(_ other: Member) -> Bool {
                         switch (self, other) {
                         case (.m1_baz, .m1_baz):
                             return true
@@ -81,39 +82,55 @@ final class TypedThrowsTests_Swift6: MockableMacroTestCase {
                         }
                     }
                 }
+                #else
+                enum Member: Mockable.Matchable, Mockable.CaseIdentifiable, Swift.Sendable {
+                    case m1_baz
+                    case m2_foo
+                    nonisolated func match(_ other: Member) -> Bool {
+                        switch (self, other) {
+                        case (.m1_baz, .m1_baz):
+                            return true
+                        case (.m2_foo, .m2_foo):
+                            return true
+                        default:
+                            return false
+                        }
+                    }
+                }
+                #endif
                 struct ReturnBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var baz: Mockable.ThrowingFunctionReturnBuilder<MockTypedErrorProtocol, ReturnBuilder, String, ExampleError, () throws -> String> {
+                    nonisolated var baz: Mockable.ThrowingFunctionReturnBuilder<MockTypedErrorProtocol, ReturnBuilder, String, ExampleError, () throws -> String> {
                         .init(mocker, kind: .m1_baz)
                     }
-                    func foo() -> Mockable.ThrowingFunctionReturnBuilder<MockTypedErrorProtocol, ReturnBuilder, Void, ExampleError, () throws -> Void> {
+                    nonisolated func foo() -> Mockable.ThrowingFunctionReturnBuilder<MockTypedErrorProtocol, ReturnBuilder, Void, ExampleError, () throws -> Void> {
                         .init(mocker, kind: .m2_foo)
                     }
                 }
                 struct ActionBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var baz: Mockable.ThrowingFunctionActionBuilder<MockTypedErrorProtocol, ActionBuilder> {
+                    nonisolated var baz: Mockable.ThrowingFunctionActionBuilder<MockTypedErrorProtocol, ActionBuilder> {
                         .init(mocker, kind: .m1_baz)
                     }
-                    func foo() -> Mockable.ThrowingFunctionActionBuilder<MockTypedErrorProtocol, ActionBuilder> {
+                    nonisolated func foo() -> Mockable.ThrowingFunctionActionBuilder<MockTypedErrorProtocol, ActionBuilder> {
                         .init(mocker, kind: .m2_foo)
                     }
                 }
                 struct VerifyBuilder: Mockable.Builder {
                     private let mocker: Mocker
-                    init(mocker: Mocker) {
+                    nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    var baz: Mockable.ThrowingFunctionVerifyBuilder<MockTypedErrorProtocol, VerifyBuilder> {
+                    nonisolated var baz: Mockable.ThrowingFunctionVerifyBuilder<MockTypedErrorProtocol, VerifyBuilder> {
                         .init(mocker, kind: .m1_baz)
                     }
-                    func foo() -> Mockable.ThrowingFunctionVerifyBuilder<MockTypedErrorProtocol, VerifyBuilder> {
+                    nonisolated func foo() -> Mockable.ThrowingFunctionVerifyBuilder<MockTypedErrorProtocol, VerifyBuilder> {
                         .init(mocker, kind: .m2_foo)
                     }
                 }

--- a/Tests/MockableTests/BuildTests.swift
+++ b/Tests/MockableTests/BuildTests.swift
@@ -112,3 +112,18 @@ protocol TestSendable: Sendable {
 public protocol TestReservedKeyword {
     func example(for: String) async throws -> String
 }
+
+#if swift(>=6.1)
+@Mockable
+nonisolated protocol NonisolatedProtocol {
+    func foo()
+}
+#endif
+
+@Mockable
+protocol AttributedRequirementProtocol {
+    #if swift(>=0)
+    @available(*, deprecated)
+    #endif
+    func foo()
+}

--- a/Tests/MockableTests/VerifyTests.swift
+++ b/Tests/MockableTests/VerifyTests.swift
@@ -115,7 +115,7 @@ final class VerifyTests: XCTestCase {
         given(mock).getUser(for: .any).willReturn(.test1)
 
         Task {
-            try await Task.sleep(for: .seconds(1))
+            try await Task.sleep(seconds: 1)
             _ = try self.mock.getUser(for: UUID())
         }
 


### PR DESCRIPTION
# Fix Swift 6.1 and 6.2 Issues

## Overview

As noted in #121, there are multiple issues with the current macro expansion on Swift 6.1 and 6.2, especially when using the library in default MainActor isolation mode. This PR adds support for Swift 6.1 and 6.2 by addressing these issues, mostly related to Swift's enhanced isolation and modifier handling.

## Issues Fixed

### Duplicate `nonisolated` Modifiers

**Issue:** In Swift 6.1+, type declarations can be marked as `nonisolated`. Since Mockable copies modifiers from the protocol to mock members, this resulted in duplicate `nonisolated` keywords since some members were already explicitly marked as `nonisolated`.

**Solution:** Filter `nonisolated` from the modifiers applied to individual members to prevent duplication.

### MainActor Isolated Hashable Conformance Breaking `Member` Enum

**Issue:** Swift 6.1 introduced isolated conformances, which caused a subtle but breaking bug in generated mocks. When using the library in default MainActor isolation environments, all nested types inside the mock (including the `Member` enum) inherit that isolation. This caused the following error:

```
Main actor-isolated conformance of 'MockTestProtocol.Member' to 'CaseIdentifiable' 
cannot satisfy conformance requirement for a 'Sendable' type parameter 'Self.Member'
```

What causes this error is that the `Member` enum's auto-generated `Equatable` and `Hashable` conformances (that are required by `CaseIdentifiable`) become `MainActor`-isolated, violating the `Sendable` requirement.

**Solution:** Generate the `Member` enum with a Swift version check that conditionally applies the `nonisolated` specifier to the entire enum declaration for Swift 6.1+:

```swift
#if swift(>=6.1)
nonisolated enum Member { ... }
#else
enum Member { ... }
#endif
```
This ensures the conformances are `nonisolated` in Swift 6.1+, satisfying the `Sendable` requirement.

**Alternatives Considered:**
- ❌ Generate `extension MockClass.Member: nonisolated Hashable {}` via a dedicated new macro that is applied using an if config clause — Not possible due to macro limitations.
- ❌ Apply `nonisolated` to the entire mock declaration — Would require `#if swift(>=6.1)` inside the macro implementation, making the macro expansion non-deterministic and untestable across Swift versions.

### Builder Method Attribute Inheritance

**Issue:** Builder methods (for registering side effects and verifications) were inheriting **all** attributes from the original protocol methods, not just `@available`. This included:
- Behavioral modifiers like `@ViewBuilder`, `@discardableResult`, etc., which shouldn't affect builder registration methods
- Global actor attributes like `@MainActor`, which conflict with Mockable's internal lock-based synchronization

**Solution:** Filter builder method attributes to only inherit `@available`. This allows builders to be called synchronously from any isolation context while Mockable's internals handle data race safety via the mocker's internal locking mechanism.
