### PR TITLE
fix: report issue before fatal errors

### DIFF
--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -241,7 +241,9 @@ extension Mocker {
                 if case .value(let value) = fallback {
                     return value
                 } else {
-                    fatalError(notMockedMessage(member, value: V.self))
+                    let message = notMockedMessage(member, value: V.self)
+                    reportIssue(message)
+                    fatalError(message)
                 }
             }
 
@@ -275,8 +277,9 @@ extension Mocker {
                     }
                 }
             }
-
-            fatalError(genericNotMockedMessage(member, value: V.self))
+            let message = genericNotMockedMessage(member, value: V.self)
+            reportIssue(message)
+            fatalError(message)
         }
     }
 }

--- a/Sources/Mockable/Models/Parameter+Match.swift
+++ b/Sources/Mockable/Models/Parameter+Match.swift
@@ -5,6 +5,8 @@
 //  Created by Kolos Foltanyi on 2023. 11. 25..
 //
 
+import IssueReporting
+
 extension Parameter {
     private func match(_ parameter: Parameter<Value>, using comparator: Matcher.Comparator<Value>?) -> Bool {
         switch (self, parameter) {
@@ -14,6 +16,7 @@ extension Parameter {
         case (.matching(let matcher), .value(let value)): return matcher(value)
         case (.value(let value1), .value(let value2)):
             guard let comparator else {
+                reportIssue(noComparatorMessage)
                 fatalError(noComparatorMessage)
             }
             return comparator(value1, value2)

--- a/Sources/Mockable/Models/Parameter.swift
+++ b/Sources/Mockable/Models/Parameter.swift
@@ -5,6 +5,8 @@
 //  Created by Kolos Foltanyi on 2023. 11. 13..
 //
 
+import IssueReporting
+
 /// An enumeration representing different types of parameters used in mocking.
 public enum Parameter<Value>: @unchecked Sendable {
     /// Matches any value.
@@ -37,6 +39,7 @@ extension Parameter {
                       let right = right as? Value else { return false }
 
                 guard let comparator = Matcher.comparator(for: Value.self) else {
+                    reportIssue(noComparatorMessage)
                     fatalError(noComparatorMessage)
                 }
                 return comparator(left, right)


### PR DESCRIPTION
This PR aims to help developer experience by reporting failures (XCTFail of Issue.report) before `fatalErrors` in case of unrecoverable errors like calling an unmocked method. This can prevent crashes when XCTest is used in combination with using `continueOnFailure = false` in your test cases. Unfortunately Swift Testing has no similar feature so these kind of crashes are unavoidable there.