### PR TITLE
fix(macro): default untyped throws to any Swift.Error

### DIFF
--- a/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
+++ b/Sources/MockableMacro/Factory/Buildable/Function+Buildable.swift
@@ -117,7 +117,10 @@ extension FunctionRequirement {
     private var defaultErrorType: some TypeSyntaxProtocol {
         SomeOrAnyTypeSyntax(
             someOrAnySpecifier: .keyword(.any),
-            constraint: IdentifierTypeSyntax(name: NS.Error)
+            constraint: MemberTypeSyntax(
+                baseType: IdentifierTypeSyntax(name: NS.Swift),
+                name: NS.Error
+            )
         )
     }
 

--- a/Tests/MockableMacroTests/FunctionEffectTests.swift
+++ b/Tests/MockableMacroTests/FunctionEffectTests.swift
@@ -99,10 +99,10 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     nonisolated init(mocker: Mocker) {
                         self.mocker = mocker
                     }
-                    nonisolated func returnsAndThrows() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, any Error, () throws -> String> {
+                    nonisolated func returnsAndThrows() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, String, any Swift.Error, () throws -> String> {
                         .init(mocker, kind: .m1_returnsAndThrows)
                     }
-                    nonisolated func canThrowError() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, () throws -> Void> {
+                    nonisolated func canThrowError() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Swift.Error, () throws -> Void> {
                         .init(mocker, kind: .m2_canThrowError)
                     }
                 }
@@ -343,10 +343,10 @@ final class FunctionEffectTests: MockableMacroTestCase {
                     nonisolated func asyncFunction() -> Mockable.FunctionReturnBuilder<MockTest, ReturnBuilder, Void, () -> Void> {
                         .init(mocker, kind: .m1_asyncFunction)
                     }
-                    nonisolated func asyncThrowingFunction() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, () throws -> Void> {
+                    nonisolated func asyncThrowingFunction() -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Swift.Error, () throws -> Void> {
                         .init(mocker, kind: .m2_asyncThrowingFunction)
                     }
-                    nonisolated func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Error, (@escaping () async throws -> Void) throws -> Void> {
+                    nonisolated func asyncParamFunction(param: Parameter<() async throws -> Void>) -> Mockable.ThrowingFunctionReturnBuilder<MockTest, ReturnBuilder, Void, any Swift.Error, (@escaping () async throws -> Void) throws -> Void> {
                         .init(mocker, kind: .m3_asyncParamFunction(param: param))
                     }
                 }

--- a/Tests/MockableTests/ErrorShadowingCompileTests.swift
+++ b/Tests/MockableTests/ErrorShadowingCompileTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import Mockable
+
+private typealias Error = Int
+
+@Mockable
+private protocol ShadowedErrorTypealiasService {
+    func throwingMethod() throws
+}
+
+final class ErrorShadowingCompileTests: XCTestCase {
+    func test_shadowed_error_typealias_allows_macro_expansion() {
+        _ = MockShadowedErrorTypealiasService()
+    }
+}


### PR DESCRIPTION
Emit any Swift.Error for untyped throwing requirements in generated builders.

This keeps Error disambiguation (Swift.Error) and avoids ExistentialAny diagnostics for generated mocks compiled with stricter warning settings.

Add a compact compile-regression test that shadows Error with a typealias, which fails to compile with unqualified Error codegen.