### PR TITLE
Fix race condition on concurrent first invocations

### DIFF
--- a/Sources/Mockable/Mocker/Mocker.swift
+++ b/Sources/Mockable/Mocker/Mocker.swift
@@ -28,22 +28,14 @@ public class Mocker<Service: MockableService>: @unchecked Sendable {
     // MARK: Private Properties
 
     /// Dictionary to store expected return values for each member.
-    private var returns = LockedValue<[Member: [Return]]>([:])
+    private let returns = LockedValue<[Member: [Return]]>([:])
     /// Dictionary to store actions to be performed on each member.
-    private var actions = LockedValue<[Member: [Action]]>([:])
+    private let actions = LockedValue<[Member: [Action]]>([:])
     /// Array to store invocations of members.
-    private lazy var invocations = LockedValue<[Member]>([]) { [invocationsSubject] newValue in
-        Task {
-            #if swift(>=6.0) && !swift(>=6.1)
-            invocationsSubject.send(newValue)
-            #else
-            await invocationsSubject.send(newValue)
-            #endif
-        }
-    }
+    private let invocations: LockedValue<[Member]>
 
     /// Subject to track invocations.
-    private var invocationsSubject = AsyncSubject<[Member]>([])
+    private let invocationsSubject: AsyncSubject<[Member]>
 
     /// Resolved relaxation policy to use when missing return values.
     private var currentPolicy: MockerPolicy {
@@ -55,6 +47,12 @@ public class Mocker<Service: MockableService>: @unchecked Sendable {
     /// Initializes a new instance of `Mocker`.
     public init(policy: MockerPolicy? = nil) {
         self.policy = policy
+        self.invocationsSubject = AsyncSubject<[Member]>([])
+        self.invocations = LockedValue([]) { [subject = self.invocationsSubject] newValue in
+            Task {
+                await subject.send(newValue)
+            }
+        }
     }
 
     // MARK: Public Methods

--- a/Tests/MockableTests/ConcurrentInvocationTests.swift
+++ b/Tests/MockableTests/ConcurrentInvocationTests.swift
@@ -1,0 +1,35 @@
+//
+//  ConcurrentInvocationTests.swift
+//
+//
+//  Created by Jalal Al-Awqati on 30.04.26.
+//
+
+import XCTest
+import Mockable
+
+final class ConcurrentInvocationTests: XCTestCase {
+
+    // MARK: Tests
+
+    func test_concurrentFirstInvocations_allCallCountsAreRecorded() async {
+        for _ in 0..<10000 {
+            let mock = MockTestService<String>()
+            given(mock).modify(user: .any).willReturn(0)
+            given(mock).update(products: .any).willReturn(0)
+            given(mock).getUser(for: .any).willReturn(.test1)
+
+            let box = UncheckedBox(mock)
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { _ = box.value.modify(user: .test1) }
+                group.addTask { _ = box.value.update(products: [.test]) }
+                group.addTask { _ = try? box.value.getUser(for: UUID()) }
+            }
+
+            verify(mock)
+                .modify(user: .any).called(.exactly(1))
+                .update(products: .any).called(.exactly(1))
+                .getUser(for: .any).called(.exactly(1))
+        }
+    }
+}

--- a/Tests/MockableTests/Helpers/UncheckedBox.swift
+++ b/Tests/MockableTests/Helpers/UncheckedBox.swift
@@ -1,0 +1,11 @@
+//
+//  UncheckedBox.swift
+//
+//
+//  Created by Jalal Al-Awqati on 30.04.26.
+//
+
+final class UncheckedBox<T>: @unchecked Sendable {
+    let value: T
+    init(_ value: T) { self.value = value }
+}


### PR DESCRIPTION
`invocations` was a private lazy var. Swift lazy vars are not thread-safe, and if multiple threads access one before it's initialized, each creates its own instance and only the last one is kept. This caused verify to sometimes report 0 invocations for methods that were called, when those calls happened concurrently (e.g. via `async let`)

The fix is to initialize `invocations` eagerly in init(). Also changed `returns`, `actions`, `invocations` and invocationsSubject from `var` to `let`